### PR TITLE
t/23: Introduced the Plugin loading API

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function( grunt ) {
 					'CKEDITOR': false,
 					'bender': false
 				},
+				predef: [ '-Promise' ],
 				ignores: ignoreFiles
 			}
 		},

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -62,7 +62,14 @@ CKEDITOR.define( [ 'editor', 'mvc/collection', 'promise', 'config' ], function( 
 					that.instances.remove( editor );
 				} );
 
-				resolve( editor );
+				resolve(
+					// Initializes the editor, which returns a promise.
+					editor.init()
+						.then( function() {
+							// After initialization, return the created editor.
+							return editor;
+						} )
+				);
 			} );
 		},
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -54,12 +54,12 @@ CKEDITOR.define( [ 'mvc/model', 'editorconfig', 'plugincollection' ], function( 
 		/**
 		 * Initializes the editor instance object after its creation.
 		 *
-		 * The initialization consists on the following procedures:
+		 * The initialization consists of the following procedures:
 		 *
 		 *  * Load and initialize the configured plugins.
 		 *  * TODO: Add other procedures here.
 		 *
-		 * This method should be rarely used as `CKEDITOR.create` calls it one should never use the `Editor` contrusctor
+		 * This method should be rarely used as `CKEDITOR.create` calls it one should never use the `Editor` constructor
 		 * directly.
 		 *
 		 * @returns {Promise} A promise which resolves once the initialization is completed.

--- a/src/editor.js
+++ b/src/editor.js
@@ -11,7 +11,7 @@
  * @class Editor
  */
 
-CKEDITOR.define( [ 'mvc/model', 'editorconfig' ], function( Model, EditorConfig ) {
+CKEDITOR.define( [ 'mvc/model', 'editorconfig', 'plugincollection' ], function( Model, EditorConfig, PluginCollection ) {
 	var Editor = Model.extend( {
 		/**
 		 * Creates a new instance of the Editor class.
@@ -42,6 +42,46 @@ CKEDITOR.define( [ 'mvc/model', 'editorconfig' ], function( Model, EditorConfig 
 			 * @type {Config}
 			 */
 			this.config = new EditorConfig( config );
+
+			/**
+			 * The plugins loaded and in use by this editor instance.
+			 *
+			 * @type {PluginCollection}
+			 */
+			this.plugins = new PluginCollection( this );
+		},
+
+		/**
+		 * Initializes the editor instance object after its creation.
+		 *
+		 * The initialization consists on the following procedures:
+		 *
+		 *  * Load and initialize the configured plugins.
+		 *  * TODO: Add other procedures here.
+		 *
+		 * This method should be rarely used as `CKEDITOR.create` calls it one should never use the `Editor` contrusctor
+		 * directly.
+		 *
+		 * @returns {Promise} A promise which resolves once the initialization is completed.
+		 */
+		init: function() {
+			var that = this;
+			var config = this.config;
+
+			// Create and cache a promise that resolves when all initialization procedures get resolved.
+			this._initPromise = this._initPromise || Promise.all( [
+				initPlugins()
+			] );
+
+			return this._initPromise;
+
+			function initPlugins() {
+				if ( config.plugins ) {
+					return that.plugins.load( config.plugins );
+				}
+
+				return Promise.resolve();
+			}
 		},
 
 		/**

--- a/src/editor.js
+++ b/src/editor.js
@@ -11,7 +11,12 @@
  * @class Editor
  */
 
-CKEDITOR.define( [ 'mvc/model', 'editorconfig', 'plugincollection' ], function( Model, EditorConfig, PluginCollection ) {
+CKEDITOR.define( [
+	'mvc/model',
+	'editorconfig',
+	'plugincollection',
+	'promise'
+], function( Model, EditorConfig, PluginCollection, Promise ) {
 	var Editor = Model.extend( {
 		/**
 		 * Creates a new instance of the Editor class.

--- a/src/editor.js
+++ b/src/editor.js
@@ -90,17 +90,17 @@ CKEDITOR.define( [
 
 				// Chain it with promises that resolve with the init() call of every plugin.
 				for ( var i = 0; i < that.plugins.length; i++ ) {
-					promise = promise.then( getInitResolveFn( i ) );
+					promise = promise.then( callInit( i ) );
 				}
 
 				// Return the promise chain.
 				return promise;
 
-				function getInitResolveFn( index ) {
+				function callInit( index ) {
 					return function() {
-						// Resolve with the return value of init(). If it is a Promise, it'll inherit its state. For
-						// everything else it resolves immediately.
-						return Promise.resolve( that.plugins.get( index ).init() );
+						// Returns init(). If it is a promise, the next then() interation will be called only when it
+						// will be resolved, enabling asynchronous init().
+						return that.plugins.get( index ).init();
 					};
 				}
 			}

--- a/src/editor.js
+++ b/src/editor.js
@@ -70,17 +70,27 @@ CKEDITOR.define( [ 'mvc/model', 'editorconfig', 'plugincollection' ], function( 
 
 			// Create and cache a promise that resolves when all initialization procedures get resolved.
 			this._initPromise = this._initPromise || Promise.all( [
-				initPlugins()
+				loadPlugins().then( initPlugins )
 			] );
 
 			return this._initPromise;
 
+			function loadPlugins() {
+				return that.plugins.load( config.plugins );
+			}
+
 			function initPlugins() {
-				if ( config.plugins ) {
-					return that.plugins.load( config.plugins );
+				var rets = [];
+
+				// Call init() on every plugin, saving the return value in the rets array.
+				for ( var i = 0; i < that.plugins.length; i++ ) {
+					rets.push( that.plugins.get( i ).init() );
 				}
 
-				return Promise.resolve();
+				// Returns a promise that resolves when all initialization values are resolved. If they are promises,
+				// we will wait for them to resolve. If they are something else, they resolve immediately (as per
+				// Promise.all specs).
+				return Promise.all( rets );
 			}
 		},
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -80,17 +80,24 @@ CKEDITOR.define( [ 'mvc/model', 'editorconfig', 'plugincollection' ], function( 
 			}
 
 			function initPlugins() {
-				var rets = [];
+				// Start with a resolved promise.
+				var promise = Promise.resolve();
 
-				// Call init() on every plugin, saving the return value in the rets array.
+				// Chain it with promises that resolve with the init() call of every plugin.
 				for ( var i = 0; i < that.plugins.length; i++ ) {
-					rets.push( that.plugins.get( i ).init() );
+					promise = promise.then( getInitResolveFn( i ) );
 				}
 
-				// Returns a promise that resolves when all initialization values are resolved. If they are promises,
-				// we will wait for them to resolve. If they are something else, they resolve immediately (as per
-				// Promise.all specs).
-				return Promise.all( rets );
+				// Return the promise chain.
+				return promise;
+
+				function getInitResolveFn( index ) {
+					return function() {
+						// Resolve with the return value of init(). If it is a Promise, it'll inherit its state. For
+						// everything else it resolves immediately.
+						return Promise.resolve( that.plugins.get( index ).init() );
+					};
+				}
 			}
 		},
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,12 +9,18 @@
  * The base class for CKEditor plugin classes.
  *
  * @class Plugin
+ * @extends Model
  */
 
-CKEDITOR.define( function() {
-	function Plugin( editor ) {
-		this.editor = editor;
-	}
+CKEDITOR.define( [ 'mvc/model' ], function( Model ) {
+	var Plugin = Model.extend( {
+		constructor: function Plugin( editor ) {
+			// Call the base constructor.
+			Model.apply( this );
+
+			this.editor = editor;
+		}
+	} );
 
 	return Plugin;
 } );

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -19,7 +19,9 @@ CKEDITOR.define( [ 'mvc/model' ], function( Model ) {
 			Model.apply( this );
 
 			this.editor = editor;
-		}
+		},
+
+		init: function() {}
 	} );
 
 	return Plugin;

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -40,7 +40,7 @@ CKEDITOR.define( [ 'mvc/collection', 'promise' ], function( Collection, Promise 
 			// The list of plugins which are being loaded (to avoid circular references issues).
 			var loading = {};
 
-			plugins = plugins.split( ',' );
+			plugins = plugins ? plugins.split( ',' ) : [];
 
 			// Creates a promise for the loading of each plugin and returns a main promise that resolves when all are
 			// done.

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -61,6 +61,7 @@ CKEDITOR.define( [ 'mvc/collection', 'promise' ], function( Collection, Promise 
 						function( LoadedPlugin ) {
 							var loadedPlugin = new LoadedPlugin( that._editor );
 							loadedPlugin.name = plugin;
+							loadedPlugin.path = CKEDITOR.getPluginPath( plugin );
 							loadedPlugin.deps = getPluginDeps( plugin );
 
 							loading[ plugin ] = true;

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -33,6 +33,8 @@ CKEDITOR.define( [ 'mvc/collection', 'promise' ], function( Collection, Promise 
 		 * Loads a set of plugins and add them to the collection.
 		 *
 		 * @param {String} plugins A comma separated list of plugin names to get loaded.
+		 * @returns {Promise} A promise which gets resolved once all plugins are loaded and available into the
+		 * collection.
 		 */
 		load: function( plugins ) {
 			var that = this;

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -1,0 +1,68 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Manages a list of CKEditor plugins, including loading, initialization and destruction.
+ *
+ * @class PluginCollection
+ * @extends Collection
+ */
+
+CKEDITOR.define( [ 'mvc/collection', 'promise' ], function( Collection, Promise ) {
+	var PluginCollection = Collection.extend( {
+		/**
+		 * Creates an instance of the PluginCollection class, initializing it with a set of plugins.
+		 *
+		 * @constructor
+		 */
+		constructor: function PluginCollection( editor ) {
+			// Call the base constructor.
+			Collection.apply( this );
+
+			this._editor = editor;
+		},
+
+		/**
+		 * Loads a set of plugins and add them to the collection.
+		 *
+		 * @param {String} plugins A comma separated list of plugin names to get loaded.
+		 */
+		load: function( plugins ) {
+			var that = this;
+
+			plugins = plugins.split( ',' );
+
+			// Creates a promise for the loading of each plugin and returns a main promise that resolves when all are
+			// done.
+			return Promise.all( plugins.map( pluginPromise ) );
+
+			// Returns a promise that will load the plugin and add it to the collection before resolving.
+			function pluginPromise( plugin ) {
+				return new Promise( function( resolve, reject ) {
+					CKEDITOR.require( [ 'plugin!' + plugin ],
+						// Success callback.
+						function( LoadedPlugin ) {
+							// Adds a new instance of the loaded plugin to the collection.
+							that.add( new LoadedPlugin( that._editor ) );
+
+							// Done! Resolve this promise.
+							resolve();
+						},
+						// Error callback.
+						function() {
+							var err = new Error( 'It was not possible to load the "' + plugin + '" plugin.' );
+							err.name = 'CKEditor Error';
+							reject( err );
+						}
+					);
+				} );
+			}
+		}
+	} );
+
+	return PluginCollection;
+} );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -47,6 +47,10 @@ CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!C' ], function() {
 	} );
 } );
 
+CKEDITOR.define( 'plugin!E', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {} );
+} );
+
 ///////////////////
 
 describe( 'constructor', function() {
@@ -113,6 +117,16 @@ describe( 'init', function() {
 				editor.plugins.get( 'D' ).init
 			);
 		} );
+	} );
+
+	it( 'should not fail if loading a plugin that doesn\'t define init()', function() {
+		var Editor = modules.editor;
+
+		editor = new Editor( element, {
+			plugins: 'E'
+		} );
+
+		return editor.init();
 	} );
 } );
 

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -100,7 +100,7 @@ describe( 'init', function() {
 		return promise;
 	} );
 
-	it( 'should return the same promise for sucessive calls', function() {
+	it( 'should return the same promise for successive calls', function() {
 		var promise = editor.init();
 
 		expect( editor.init() ).to.equal( promise );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -23,26 +23,26 @@ beforeEach( function() {
 
 // Define fake plugins to be used in tests.
 
-CKEDITOR.define( 'plugin!A', [ 'plugin' ], function() {
-	return modules.plugin.extend( {
+CKEDITOR.define( 'plugin!A', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
 		init: sinon.spy().named( 'A' )
 	} );
 } );
 
-CKEDITOR.define( 'plugin!B', [ 'plugin' ], function() {
-	return modules.plugin.extend( {
+CKEDITOR.define( 'plugin!B', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
 		init: sinon.spy().named( 'B' )
 	} );
 } );
 
-CKEDITOR.define( 'plugin!C', [ 'plugin', 'plugin!B' ], function() {
-	return modules.plugin.extend( {
+CKEDITOR.define( 'plugin!C', [ 'plugin', 'plugin!B' ], function( Plugin ) {
+	return Plugin.extend( {
 		init: sinon.spy().named( 'C' )
 	} );
 } );
 
-CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!C' ], function() {
-	return modules.plugin.extend( {
+CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!C' ], function( Plugin ) {
+	return Plugin.extend( {
 		init: sinon.spy().named( 'D' )
 	} );
 } );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -60,7 +60,7 @@ CKEDITOR.define( 'plugin!F', [ 'plugin', 'plugin!async' ], function( Plugin ) {
 
 var asyncSpy = sinon.spy().named( 'async-call-spy' );
 
-CKEDITOR.define( 'plugin!async', [ 'plugin' ], function( Plugin ) {
+CKEDITOR.define( 'plugin!async', [ 'plugin', 'promise' ], function( Plugin, Promise ) {
 	return Plugin.extend( {
 		init: sinon.spy( function() {
 			return new Promise( function( resolve ) {

--- a/tests/plugin/plugin.js
+++ b/tests/plugin/plugin.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, before, document */
+
+'use strict';
+
+var modules = bender.amd.require( 'plugin', 'editor' );
+var editor;
+
+before( function() {
+	var Editor = modules.editor;
+
+	editor = new Editor( document.body.appendChild( document.createElement( 'div' ) ) );
+} );
+
+describe( 'constructor', function() {
+	it( 'should set the `editor` property', function() {
+		var Plugin = modules.plugin;
+
+		var plugin = new Plugin( editor );
+
+		expect( plugin ).to.have.property( 'editor' ).to.equal( editor );
+	} );
+} );

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -167,7 +167,7 @@ describe( 'load', function() {
 			} );
 	} );
 
-	it( 'should throw error for invalid plugins', function() {
+	it( 'should throw an error for invalid plugins', function() {
 		var PluginCollection = modules.plugincollection;
 
 		var plugins = new PluginCollection( editor );
@@ -227,7 +227,7 @@ describe( 'add', function() {
 } );
 
 describe( 'get', function() {
-	it( 'should get plugin by name', function() {
+	it( 'should get a plugin by name', function() {
 		var PluginCollection = modules.plugincollection;
 
 		var plugins = new PluginCollection( editor );

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -80,3 +80,71 @@ describe( 'load', function() {
 			} );
 	} );
 } );
+
+describe( 'add', function() {
+	it( 'should add plugins to the collection', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		var pluginA = new PluginA();
+		var pluginB = new PluginB();
+
+		// `add()` requires the `name` property to the defined.
+		pluginA.name = 'A';
+		pluginB.name = 'B';
+
+		plugins.add( pluginA );
+		plugins.add( pluginB );
+
+		expect( plugins.length ).to.equal( 2 );
+
+		expect( plugins.get( 0 ) ).to.be.an.instanceof( PluginA );
+		expect( plugins.get( 1 ) ).to.be.an.instanceof( PluginB );
+	} );
+
+	it( 'should do nothing if the plugin is already loaded', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				// Check length before `add()`.
+				expect( plugins.length ).to.equal( 2 );
+
+				var pluginA = new PluginA();
+				pluginA.name = 'A';
+
+				plugins.add( pluginA );
+
+				// Length should not change after `add()`.
+				expect( plugins.length ).to.equal( 2 );
+			} );
+	} );
+} );
+
+describe( 'get', function() {
+	it( 'should get plugin by name', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				expect( plugins.get( 'A' ) ).to.be.an.instanceof( PluginA );
+				expect( plugins.get( 'B' ) ).to.be.an.instanceof( PluginB );
+			} );
+	} );
+
+	it( 'should return undefined for non existing plugin', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				expect( plugins.get( 'C' ) ).to.be.an( 'undefined' );
+			} );
+	} );
+} );

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -23,11 +23,11 @@ before( function() {
 
 // Create fake plugins that will be used on tests.
 
-CKEDITOR.define( 'plugin!A', [ 'plugin' ], function() {
+CKEDITOR.define( 'plugin!A', function() {
 	return PluginA;
 } );
 
-CKEDITOR.define( 'plugin!B', [ 'plugin' ], function() {
+CKEDITOR.define( 'plugin!B', function() {
 	return PluginB;
 } );
 

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, before, document */
+
+'use strict';
+
+var modules = bender.amd.require( 'plugincollection', 'plugin', 'editor' );
+var editor;
+var PluginA, PluginB, PluginC;
+
+before( function() {
+	var Editor = modules.editor;
+	var Plugin = modules.plugin;
+
+	PluginA = Plugin.extend();
+	PluginB = Plugin.extend();
+	PluginC = Plugin.extend();
+
+	editor = new Editor( document.body.appendChild( document.createElement( 'div' ) ) );
+} );
+
+// Create 3 fake plugins that will be used on tests.
+
+CKEDITOR.define( 'plugin!A', [ 'plugin' ], function() {
+	return PluginA;
+} );
+
+CKEDITOR.define( 'plugin!B', [ 'plugin' ], function() {
+	return PluginB;
+} );
+
+CKEDITOR.define( 'plugin!C', [ 'plugin' ], function() {
+	return PluginC;
+} );
+
+/////////////
+
+describe( 'load', function() {
+	it( 'should add collection items for loaded plugins', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				expect( plugins.length ).to.equal( 2 );
+
+				expect( plugins.get( 0 ) ).to.be.an.instanceof( PluginA );
+				expect( plugins.get( 1 ) ).to.be.an.instanceof( PluginB );
+			} );
+	} );
+
+	it( 'should set the `editor` property on loaded plugins', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				expect( plugins.get( 0 ).editor ).to.equal( editor );
+				expect( plugins.get( 1 ).editor ).to.equal( editor );
+			} );
+	} );
+
+	it( 'should throw error for invalid plugins', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,BAD,B' )
+			.then( function() {
+				throw new Error( 'Test error: this promise should not be resolved successfully' );
+			} )
+			.catch( function( err ) {
+				expect( err ).to.be.an.instanceof( Error );
+				expect( err.name ).to.equal( 'CKEditor Error' );
+			} );
+	} );
+} );

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -141,6 +141,32 @@ describe( 'load', function() {
 			} );
 	} );
 
+	it( 'should set the `path` property on loaded plugins', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,B' )
+			.then( function() {
+				expect( plugins.get( 'A' ).path ).to.equal( CKEDITOR.getPluginPath( 'A' ) );
+				expect( plugins.get( 'B' ).path ).to.equal( CKEDITOR.getPluginPath( 'B' ) );
+			} );
+	} );
+
+	it( 'should set the `deps` property on loaded plugins', function() {
+		var PluginCollection = modules.plugincollection;
+
+		var plugins = new PluginCollection( editor );
+
+		return plugins.load( 'A,D' )
+			.then( function() {
+				expect( plugins.get( 'A' ).deps ).to.deep.equal( [] );
+				expect( plugins.get( 'B' ).deps ).to.deep.equal( [] );
+				expect( plugins.get( 'C' ).deps ).to.deep.equal( [ 'B' ] );
+				expect( plugins.get( 'D' ).deps ).to.deep.equal( [ 'A', 'C' ] );
+			} );
+	} );
+
 	it( 'should throw error for invalid plugins', function() {
 		var PluginCollection = modules.plugincollection;
 

--- a/tests/plugincollection/plugincollection.js
+++ b/tests/plugincollection/plugincollection.js
@@ -31,20 +31,20 @@ CKEDITOR.define( 'plugin!B', function() {
 	return PluginB;
 } );
 
-CKEDITOR.define( 'plugin!C', [ 'plugin', 'plugin!B' ], function() {
-	return modules.plugin;
+CKEDITOR.define( 'plugin!C', [ 'plugin', 'plugin!B' ], function( Plugin ) {
+	return Plugin.extend();
 } );
 
-CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!A', 'plugin!C' ], function() {
-	return modules.plugin;
+CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!A', 'plugin!C' ], function( Plugin ) {
+	return Plugin.extend();
 } );
 
-CKEDITOR.define( 'plugin!E', [ 'plugin', 'plugin!F' ], function() {
-	return modules.plugin;
+CKEDITOR.define( 'plugin!E', [ 'plugin', 'plugin!F' ], function( Plugin ) {
+	return Plugin.extend();
 } );
 
-CKEDITOR.define( 'plugin!F', [ 'plugin', 'plugin!E' ], function() {
-	return modules.plugin;
+CKEDITOR.define( 'plugin!F', [ 'plugin', 'plugin!E' ], function( Plugin ) {
+	return Plugin.extend();
 } );
 
 /////////////


### PR DESCRIPTION
Fixes #23.

Note that relative updates ended up in [ckeditor5](https://github.com/ckeditor/ckeditor5), where a new test plugin has been introduced [ckeditor5-plugin-devtest](https://github.com/ckeditor/ckeditor5-plugin-devtest). Therefore `git pull` and `npm install` must be executed in `ckeditor5` to catch these updates.