### PR TITLE
t/26: Introduced the API for creators

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
+/* globals document, HTMLElement */
 
 'use strict';
 
@@ -36,24 +36,41 @@ CKEDITOR.define( [ 'editor', 'collection', 'promise', 'config' ], function( Edit
 		 *			// Manipulate "editor" here.
 		 *		} );
 		 *
-		 * @param {String|HTMLElement} element An element selector or a DOM element, which will be the source for the
-		 * created instance.
+		 * @param {String|HTMLElement|NodeList|HTMLCollection|Array} elements An element selector, an element or a list
+		 * of elements, which will be the editables of the created instance.
 		 * @returns {Promise} A promise, which will be fulfilled with the created editor.
 		 */
-		create: function( element, config ) {
+		create: function( elements, config ) {
 			var that = this;
 
 			return new Promise( function( resolve, reject ) {
 				// If a query selector has been passed, transform it into a real element.
-				if ( typeof element == 'string' ) {
-					element = document.querySelector( element );
+				if ( typeof elements == 'string' ) {
+					var query = elements;
+					elements = document.querySelectorAll( query );
 
-					if ( !element ) {
-						reject( new Error( 'Element not found' ) );
+					if ( !elements.length ) {
+						reject( new Error( 'No elements found for the query "' + query + '"' ) );
 					}
+				} else if ( elements instanceof HTMLElement ) {
+					// Transform a single element into an array.
+					elements = [ elements ];
 				}
 
-				var editor = new Editor( element, config );
+				if ( !Array.isArray( elements ) ) {
+					// Transform "array-like" to pure array.
+					elements = Array.prototype.slice.call( elements );
+				}
+
+				var editor = new Editor();
+
+				if ( config ) {
+					editor.config.set( config );
+				}
+
+				elements.forEach( function( element ) {
+					editor.editables.add( element );
+				} );
 
 				that.instances.add( editor );
 

--- a/src/config.js
+++ b/src/config.js
@@ -158,6 +158,17 @@ CKEDITOR.define( [ 'model', 'utils' ], function( Model, utils ) {
 				return source[ name ];
 			}
 
+			// Retrieve it from the parent, if it has been set.
+			if ( this.parent ) {
+				var value = this.parent[ name ];
+
+				// Retrieve from parent only if it is available in it, otherwise give a chance to take it from the
+				// definition later in the code.
+				if ( value !== undefined ) {
+					return value;
+				}
+			}
+
 			// If not found, take it from the definition.
 			if ( this.definition ) {
 				return this.definition[ name ];

--- a/src/editable.js
+++ b/src/editable.js
@@ -11,10 +11,18 @@
  * Represents an editable inside the editor.
  *
  * @class Editable
+ * @extends Model
  */
 
 CKEDITOR.define( [ 'model', 'config', 'editablecollection', 'promise' ], function( Model, Config, EditableCollection, Promise ) {
 	var Editable = Model.extend( {
+		/**
+		 * Creates an instance of the Editable class.
+		 *
+		 * @constructor
+		 * @param {HTMLElement|Editable} element The DOM element that will be linked to this editable. If an editable is
+		 * provided, that same editable is returned by the constructor.
+		 */
 		constructor: function Editable( element ) {
 			// We need to renew the module request because of cross-reference with Editable<->EditableCollection.
 			EditableCollection = CKEDITOR.require( 'editablecollection' );
@@ -31,19 +39,50 @@ CKEDITOR.define( [ 'model', 'config', 'editablecollection', 'promise' ], functio
 			 * The DOM element managed by this editable.
 			 *
 			 * @readonly
-			 * @property {HTMLElement}
+			 * @property {HTMLElement} element
 			 */
 			this.set( 'element', element );
 
+			/**
+			 * The DOM element that represents the editable view.
+			 *
+			 * @readonly
+			 * @property {HTMLElement} view
+			 */
 			this.set( 'view' );
 
+			/**
+			 * Configurations specific to this editable. It inherits configurations from parent editables.
+			 *
+			 * @readonly
+			 * @property {Config} config
+			 */
 			this.set( 'config', new Config() );
 
+			/**
+			 * The child editables of this editable.
+			 *
+			 * @readonly
+			 * @property {EditableCollection} editables
+			 */
 			this.set( 'editables', new EditableCollection( this ) );
 
 			return this;
 		},
 
+		/**
+		 * Initializes the editable.
+		 *
+		 * The initialization consists of the following procedures:
+		 *
+		 *  * Setup the editable view.
+		 *  * Initialize children.
+		 *  * Enable editing in the editable.
+		 *
+		 * This method should be rarely used as `editor.init` calls it during editor initialization.
+		 *
+		 * @returns {Promise} A promise that resolves once the initialization is completed.
+		 */
 		init: function() {
 			var that = this;
 
@@ -114,6 +153,11 @@ CKEDITOR.define( [ 'model', 'config', 'editablecollection', 'promise' ], functio
 	 * @member Editable
 	 */
 	Object.defineProperties( Editable.prototype, {
+		/**
+		 * The parent editable of this editable.
+		 *
+		 * @property {Boolean}
+		 */
 		parent: {
 			set: function( parent ) {
 				this.config.parent = parent.config;

--- a/src/editable.js
+++ b/src/editable.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Represents an editable inside the editor.
+ *
+ * @class Editable
+ */
+
+CKEDITOR.define( [ 'model', 'promise' ], function( Model, Promise ) {
+	var Editable = Model.extend( {
+		constructor: function Editable( element ) {
+			// Accept and Editable instance as parameter as well, for simplification in other parts of the code.
+			if ( element instanceof Editable ) {
+				return element;
+			}
+
+			// Call the base constructor.
+			Model.apply( this );
+
+			/**
+			 * The DOM element managed by this editable.
+			 *
+			 * @readonly
+			 * @property {HTMLElement}
+			 */
+			this.element = element;
+
+			this.isEditable = true;
+
+			return this;
+		},
+
+		/**
+		 * Sets the editable data.
+		 *
+		 * @param {String} data The data to be set into the editable.
+		 * @returns {Promise} A promise that resolves as soon as the data is processed and fully loaded inside the
+		 * editable.
+		 */
+		setData: function( data ) {
+			this.element.innerHTML = data;
+
+			return Promise.resolve();
+		},
+
+		/**
+		 * Gets the current editable data.
+		 *
+		 * @returns {String} The data.
+		 */
+		getData: function() {
+			return this.element.innerHTML;
+		}
+	} );
+
+	/**
+	 * @member Editable
+	 */
+	Object.defineProperties( Editable.prototype, {
+		/**
+		 * Indicates whether or not the editable has editing enabled.
+		 *
+		 * @property {Boolean}
+		 */
+		isEditable: {
+			get: function() {
+				return this.element.contentEditable;
+			},
+
+			set: function( value ) {
+				this.element.contentEditable = value;
+			}
+		}
+	} );
+
+	return Editable;
+} );

--- a/src/editable.js
+++ b/src/editable.js
@@ -69,7 +69,7 @@ CKEDITOR.define( [ 'model', 'promise' ], function( Model, Promise ) {
 		 */
 		isEditable: {
 			get: function() {
-				return this.element.contentEditable;
+				return ( this.element.contentEditable.toString() == 'true' );
 			},
 
 			set: function( value ) {

--- a/src/editablecollection.js
+++ b/src/editablecollection.js
@@ -1,0 +1,72 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals HTMLElement */
+
+'use strict';
+
+/**
+ * Manages a list of CKEditor plugins, including loading, initialization and destruction.
+ *
+ * @class PluginCollection
+ * @extends Collection
+ */
+
+CKEDITOR.define( [ 'collection', 'editable' ], function( Collection, Editable ) {
+	var EditableCollection = Collection.extend( {
+		/**
+		 * Creates an instance of the PluginCollection class, initializing it with a set of plugins.
+		 *
+		 * @constructor
+		 */
+		constructor: function EditableCollection( parent ) {
+			// Call the base constructor.
+			Collection.apply( this );
+
+			this.parent = parent;
+
+			var current;
+
+			/**
+			 * Points to the current default editable in the collection. It defaults to the first editable available
+			 * editable (`collection.get( 0 )`).
+			 *
+			 * @property {Editable} current
+			 */
+			Object.defineProperty( this, 'current', {
+				get: function() {
+					return current || ( this.length && this.get( 0 ) ) || null;
+				},
+
+				set: function( value ) {
+					current = value;
+				}
+			} );
+		},
+
+		/**
+		 * Adds an editable to the collection.
+		 *
+		 * @param {Editable|HTMLElement} editableOrElement The editable to be added or an element which the
+		 * editable to be added is created from.
+		 */
+		add: function( editableOrElement ) {
+			var editable = editableOrElement;
+
+			if ( editableOrElement instanceof HTMLElement ) {
+				editable = new Editable( editableOrElement );
+			}
+
+			if ( this.parent ) {
+				editable.parent = this.parent;
+			}
+
+			// Call the original implementation.
+			Collection.prototype.add.call( this, editable );
+		}
+	} );
+
+	return EditableCollection;
+} );

--- a/src/editablecollection.js
+++ b/src/editablecollection.js
@@ -10,21 +10,28 @@
 /**
  * Manages a list of CKEditor plugins, including loading, initialization and destruction.
  *
- * @class PluginCollection
+ * @class EditableCollection
  * @extends Collection
  */
 
 CKEDITOR.define( [ 'collection', 'editable' ], function( Collection, Editable ) {
 	var EditableCollection = Collection.extend( {
 		/**
-		 * Creates an instance of the PluginCollection class, initializing it with a set of plugins.
+		 * Creates an instance of the EditableCollection class.
 		 *
 		 * @constructor
+		 * @param {Editable} editable The parent editable of all editables included in this collection.
 		 */
 		constructor: function EditableCollection( parent ) {
 			// Call the base constructor.
 			Collection.apply( this );
 
+			/**
+			 * The parent editable of all editables included in this collection.
+			 *
+			 * @readonly
+			 * @property {Editable} parent
+			 */
 			this.parent = parent;
 
 			var current;

--- a/src/editor.js
+++ b/src/editor.js
@@ -150,7 +150,7 @@ CKEDITOR.define( [
 					return that._creator.create();
 				}
 
-				return 0;
+				// For now, we're assuming that at least one creator will be available, so no error check is done.
 			}
 
 			function initEditables() {

--- a/src/editor.js
+++ b/src/editor.js
@@ -68,8 +68,8 @@ CKEDITOR.define( [
 		 * The initialization consists of the following procedures:
 		 *
 		 *  * Loads and initializes the configured plugins.
-		 *  * Fires the editor creator.
 		 *  * Initializes all editables.
+		 *  * Fires the editor creator.
 		 *
 		 * This method should be rarely used as `CKEDITOR.create` calls it. One should never use the `Editor`
 		 * constructor directly.
@@ -85,8 +85,8 @@ CKEDITOR.define( [
 				.then( loadPlugins )
 				.then( initPlugins )
 				.then( prepareData )
-				.then( fireCreator )
 				.then( initEditables )
+				.then( fireCreator )
 				.then( loadData );
 
 			return this._initPromise;
@@ -131,6 +131,16 @@ CKEDITOR.define( [
 				}
 			}
 
+			function initEditables() {
+				var promises = [];
+
+				for ( var i = 0; i < that.editables.length; i++ ) {
+					promises.push( that.editables.get( i ).init() );
+				}
+
+				return Promise.all( promises );
+			}
+
 			function fireCreator() {
 				// Take the name of the creator to use (config or any of the registered ones).
 				var creatorName = config.creator || Object.keys( that._creators )[ 0 ];
@@ -151,16 +161,6 @@ CKEDITOR.define( [
 				}
 
 				// For now, we're assuming that at least one creator will be available, so no error check is done.
-			}
-
-			function initEditables() {
-				var promises = [];
-
-				for ( var i = 0; i < that.editables.length; i++ ) {
-					promises.push( that.editables.get( i ).init() );
-				}
-
-				return Promise.all( promises );
 			}
 
 			function loadData() {

--- a/src/editor.js
+++ b/src/editor.js
@@ -184,9 +184,6 @@ CKEDITOR.define( [
 			this._destroyPromise = this._destroyPromise || Promise.resolve()
 				.then( function() {
 					return that._creator && that._creator.destroy();
-				} )
-				.then( function() {
-					that.element = undefined;
 				} );
 
 			return this._destroyPromise;

--- a/src/editor.js
+++ b/src/editor.js
@@ -38,6 +38,7 @@ CKEDITOR.define( [
 			 * global configurations available in {@link CKEDITOR.config} if configurations are not found in the
 			 * instance itself.
 			 *
+			 * @readonly
 			 * @type {Config} config
 			 */
 			this.set( 'config', new EditorConfig() );
@@ -45,10 +46,17 @@ CKEDITOR.define( [
 			/**
 			 * The plugins loaded and in use by this editor instance.
 			 *
+			 * @readonly
 			 * @type {PluginCollection} plugins
 			 */
 			this.set( 'plugins', new PluginCollection( this ) );
 
+			/**
+			 * The editables attached to this editor instance.
+			 *
+			 * @readonly
+			 * @type {EditableCollection} editables
+			 */
 			this.set( 'editables', new EditableCollection() );
 
 			this._creators = {};
@@ -59,11 +67,12 @@ CKEDITOR.define( [
 		 *
 		 * The initialization consists of the following procedures:
 		 *
-		 *  * Load and initialize the configured plugins.
-		 *  * TODO: Add other procedures here.
+		 *  * Loads and initializes the configured plugins.
+		 *  * Fires the editor creator.
+		 *  * Initializes all editables.
 		 *
-		 * This method should be rarely used as `CKEDITOR.create` calls it one should never use the `Editor` constructor
-		 * directly.
+		 * This method should be rarely used as `CKEDITOR.create` calls it. One should never use the `Editor`
+		 * constructor directly.
 		 *
 		 * @returns {Promise} A promise that resolves once the initialization is completed.
 		 */
@@ -183,6 +192,14 @@ CKEDITOR.define( [
 			return this._destroyPromise;
 		},
 
+		/**
+		 * Sets the editor data.
+		 *
+		 * **Attention**: setting the editor data may be an asynchronous operation.
+		 *
+		 * @param {String} data The data to be set.
+		 * @returns {Promise} A promise that resolves once the data is fully loaded in the editor.
+		 */
 		setData: function( data ) {
 			if ( this.editables.current ) {
 				this._data = undefined;
@@ -195,6 +212,11 @@ CKEDITOR.define( [
 			return Promise.resolve();
 		},
 
+		/**
+		 * Gets the editor data.
+		 *
+		 * @returns {String} The current data.
+		 */
 		getData: function() {
 			if ( this.editables.current ) {
 				return this.editables.current.getData();
@@ -203,6 +225,18 @@ CKEDITOR.define( [
 			return this._data || '';
 		},
 
+		/**
+		 * Registers a creator into the editor.
+		 *
+		 * Creators are usually plugins that take the responsibility of bootstrapping the UI of the editor instance.
+		 * Therefore this method has little use out of such plugins scope.
+		 *
+		 * Usually just one creator will be registered but it is possible to have multiple creators available. In such
+		 * case, the `creator` configuration must be used to specify which one to use.
+		 *
+		 * @param {String} name The name of the creator. This is the name used in the `creator` configuration.
+		 * @param {Function} creatorClass The JavaScript class (constructor function) that
+		 */
 		addCreator: function( name, creatorClass ) {
 			this._creators[ name ] = creatorClass;
 		}

--- a/src/editor.js
+++ b/src/editor.js
@@ -68,8 +68,8 @@ CKEDITOR.define( [
 		 * The initialization consists of the following procedures:
 		 *
 		 *  * Loads and initializes the configured plugins.
-		 *  * Initializes all editables.
 		 *  * Fires the editor creator.
+		 *  * Initializes all editables.
 		 *
 		 * This method should be rarely used as `CKEDITOR.create` calls it. One should never use the `Editor`
 		 * constructor directly.
@@ -85,8 +85,8 @@ CKEDITOR.define( [
 				.then( loadPlugins )
 				.then( initPlugins )
 				.then( prepareData )
-				.then( initEditables )
 				.then( fireCreator )
+				.then( initEditables )
 				.then( loadData );
 
 			return this._initPromise;
@@ -131,16 +131,6 @@ CKEDITOR.define( [
 				}
 			}
 
-			function initEditables() {
-				var promises = [];
-
-				for ( var i = 0; i < that.editables.length; i++ ) {
-					promises.push( that.editables.get( i ).init() );
-				}
-
-				return Promise.all( promises );
-			}
-
 			function fireCreator() {
 				// Take the name of the creator to use (config or any of the registered ones).
 				var creatorName = config.creator || Object.keys( that._creators )[ 0 ];
@@ -161,6 +151,16 @@ CKEDITOR.define( [
 				}
 
 				// For now, we're assuming that at least one creator will be available, so no error check is done.
+			}
+
+			function initEditables() {
+				var promises = [];
+
+				for ( var i = 0; i < that.editables.length; i++ ) {
+					promises.push( that.editables.get( i ).init() );
+				}
+
+				return Promise.all( promises );
 			}
 
 			function loadData() {

--- a/tests/ckeditor/ckeditor.html
+++ b/tests/ckeditor/ckeditor.html
@@ -1,2 +1,0 @@
-<div id="content"></div>
-<div class="editor"></div>

--- a/tests/config/config.js
+++ b/tests/config/config.js
@@ -206,6 +206,28 @@ describe( 'get', function() {
 	it( 'should return undefined for non existing deep configuration', function() {
 		expect( config.get( 'resize.invalid.value' ) ).to.be.undefined();
 	} );
+
+	it( 'should retrieve from the parent', function() {
+		var Config = modules.config;
+
+		config.parent = new Config( {
+			parentTest: 1
+		} );
+
+		expect( config.get( 'parentTest' ) ).to.equal( 1 );
+	} );
+
+	it( 'should retrieve from definition if not in the parent', function() {
+		var Config = modules.config;
+
+		config.parent = new Config( {
+			parentTest: 1
+		} );
+
+		config.define( 'defineTest', 2 );
+
+		expect( config.get( 'defineTest' ) ).to.equal( 2 );
+	} );
 } );
 
 describe( 'define', function() {

--- a/tests/editable/editable.js
+++ b/tests/editable/editable.js
@@ -1,0 +1,97 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, beforeEach, document */
+
+'use strict';
+
+var modules = bender.amd.require( 'editable' );
+
+var editable;
+var element;
+var elementInnerHTML = '<p>Test</p>';
+
+beforeEach( function() {
+	var Editable = modules.editable;
+
+	element = document.createElement( 'div' );
+	element.innerHTML = elementInnerHTML;
+	document.body.appendChild( element );
+
+	editable = new Editable( element );
+} );
+
+describe( 'constructor', function() {
+	it( 'should set the `element` property', function() {
+		expect( editable ).to.have.property( 'element' ).to.equal( element );
+	} );
+
+	it( 'should accept an Editable instance as parameter', function() {
+		var Editable = modules.editable;
+
+		var newEditable = new Editable( editable );
+
+		expect( newEditable ).to.equal( editable );
+	} );
+
+	it( 'should make the element editable', function() {
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( element.contentEditable.toString() ).to.equal( 'true' );
+	} );
+} );
+
+describe( 'setData', function() {
+	it( 'should set the element innerHTML', function() {
+		var data = 'TEST';
+
+		return editable.setData( data ).then( function() {
+			expect( element.innerHTML ).to.equal( data );
+		} );
+	} );
+} );
+
+describe( 'setData', function() {
+	it( 'should get the element innerHTML', function() {
+		var data = 'TEST';
+
+		element.innerHTML = data;
+
+		expect( editable.getData() ).to.equal( data );
+	} );
+} );
+
+describe( 'isEditable', function() {
+	it( 'should set element.contentEditable (false)', function() {
+		element.contentEditable = true;
+
+		editable.isEditable = false;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( element.contentEditable.toString() ).to.equal( 'false' );
+	} );
+
+	it( 'should set element.contentEditable (true)', function() {
+		element.contentEditable = false;
+
+		editable.isEditable = true;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( element.contentEditable.toString() ).to.equal( 'true' );
+	} );
+
+	it( 'should get the element.contentEditable (false)', function() {
+		element.contentEditable = false;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( editable.isEditable ).to.be.false();
+	} );
+
+	it( 'should get the element.contentEditable (true)', function() {
+		element.contentEditable = true;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( editable.isEditable ).to.be.true();
+	} );
+} );

--- a/tests/editable/editable.js
+++ b/tests/editable/editable.js
@@ -3,11 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals describe, it, expect, beforeEach, document */
+/* globals describe, it, expect, beforeEach, document, sinon */
 
 'use strict';
 
-var modules = bender.amd.require( 'editable' );
+var modules = bender.amd.require( 'editable', 'editablecollection', 'config' );
 
 var editable;
 var element;
@@ -28,6 +28,23 @@ describe( 'constructor', function() {
 		expect( editable ).to.have.property( 'element' ).to.equal( element );
 	} );
 
+	it( 'should set the `view` property', function() {
+		expect( 'view' in editable ).to.be.true();
+	} );
+
+	it( 'should set the `config` property', function() {
+		var Config = modules.config;
+
+		expect( editable ).to.have.property( 'config' ).to.be.an.instanceof( Config );
+	} );
+
+	it( 'should set the `editables` property', function() {
+		var EditableCollection = modules.editablecollection;
+
+		expect( editable ).to.have.property( 'editables' ).to.be.an.instanceof( EditableCollection );
+		expect( editable.editables ).to.have.length( 0 );
+	} );
+
 	it( 'should accept an Editable instance as parameter', function() {
 		var Editable = modules.editable;
 
@@ -35,10 +52,36 @@ describe( 'constructor', function() {
 
 		expect( newEditable ).to.equal( editable );
 	} );
+} );
+
+describe( 'init', function() {
+	it( 'should set the editable view', function() {
+		return editable.init().then( function() {
+			expect( editable.view ).to.equal( element );
+		} );
+	} );
+
+	it( 'should call init on children', function() {
+		var Editable = modules.editable;
+
+		var childElement = document.createElement( 'div' );
+		document.body.appendChild( childElement );
+
+		var child = new Editable( childElement );
+		var spy = sinon.spy( child, 'init' );
+
+		editable.editables.add( child );
+
+		return editable.init().then( function() {
+			sinon.assert.called( spy );
+		} );
+	} );
 
 	it( 'should make the element editable', function() {
-		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
-		expect( element.contentEditable.toString() ).to.equal( 'true' );
+		return editable.init().then( function() {
+			// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+			expect( element.contentEditable.toString() ).to.equal( 'true' );
+		} );
 	} );
 } );
 
@@ -50,9 +93,26 @@ describe( 'setData', function() {
 			expect( element.innerHTML ).to.equal( data );
 		} );
 	} );
+
+	it( 'should set the view innerHTML after init()', function() {
+		var data = 'TEST';
+
+		var viewElement = document.createElement( 'div' );
+		document.body.appendChild( viewElement );
+
+		editable.view = viewElement;
+
+		return editable.init()
+			.then( function() {
+				return editable.setData( data );
+			} )
+			.then( function() {
+				expect( viewElement.innerHTML ).to.equal( data );
+			} );
+	} );
 } );
 
-describe( 'setData', function() {
+describe( 'getData', function() {
 	it( 'should get the element innerHTML', function() {
 		var data = 'TEST';
 
@@ -60,9 +120,82 @@ describe( 'setData', function() {
 
 		expect( editable.getData() ).to.equal( data );
 	} );
+
+	it( 'should get the view innerHTML after init()', function() {
+		var data = 'TEST';
+
+		var viewElement = document.createElement( 'div' );
+		viewElement.innerHTML = data;
+		document.body.appendChild( viewElement );
+
+		editable.view = viewElement;
+
+		return editable.init()
+			.then( function() {
+				expect( editable.getData() ).to.equal( data );
+			} );
+	} );
+
+	it( 'should get the element "value" if it is a textarea', function() {
+		var Editable = modules.editable;
+
+		var data = 'TEST';
+
+		var textarea = document.createElement( 'textarea' );
+		textarea.value = data;
+		document.body.appendChild( textarea );
+
+		editable = new Editable( textarea );
+
+		expect( editable.getData() ).to.equal( data );
+	} );
 } );
 
-describe( 'isEditable', function() {
+describe( 'parent', function() {
+	it( 'should get the parent', function() {
+		var Editable = modules.editable;
+
+		var parent = new Editable( document.body.appendChild( document.createElement( 'div' ) ) );
+
+		editable.parent = parent;
+
+		expect( editable.parent ).to.equal( parent );
+	} );
+
+	it( 'should set config.parent', function() {
+		var Editable = modules.editable;
+
+		var parent = new Editable( document.body.appendChild( document.createElement( 'div' ) ) );
+
+		editable.parent = parent;
+
+		expect( editable.config.parent ).to.equal( parent.config );
+	} );
+} );
+
+describe( 'isEditable (before init())', function() {
+	it( 'should do nothing on set', function() {
+		element.contentEditable = true;
+
+		editable.isEditable = false;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( element.contentEditable.toString() ).to.equal( 'true' );
+	} );
+
+	it( 'should get `false` always', function() {
+		element.contentEditable = true;
+
+		// Use toString() because browsers return the string "true" not a boolean. So, just to be sure.
+		expect( editable.isEditable ).to.be.false();
+	} );
+} );
+
+describe( 'isEditable (after init())', function() {
+	beforeEach( function() {
+		return editable.init();
+	} );
+
 	it( 'should set element.contentEditable (false)', function() {
 		element.contentEditable = true;
 

--- a/tests/editable/editable.js
+++ b/tests/editable/editable.js
@@ -83,6 +83,12 @@ describe( 'init', function() {
 			expect( element.contentEditable.toString() ).to.equal( 'true' );
 		} );
 	} );
+
+	it( 'should return the same promise for successive calls', function() {
+		var promise = editable.init();
+
+		expect( editable.init() ).to.equal( promise );
+	} );
 } );
 
 describe( 'setData', function() {

--- a/tests/editablecollection/editablecollection.js
+++ b/tests/editablecollection/editablecollection.js
@@ -1,0 +1,84 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, before, document */
+
+'use strict';
+
+var modules = bender.amd.require( 'editablecollection', 'editable' );
+
+var EditableCollection;
+var Editable;
+
+before( function() {
+	EditableCollection = modules.editablecollection;
+	Editable = modules.editable;
+} );
+
+describe( 'current', function() {
+	it( 'should point to the first available editable by default', function() {
+		var el = document.createElement( 'div' );
+
+		var editables = new EditableCollection();
+
+		editables.add( el );
+
+		expect( editables.current ).to.equal( editables.get( 0 ) );
+	} );
+
+	it( 'should return the editable that has been set', function() {
+		var editables = new EditableCollection();
+
+		editables.add( document.createElement( 'div' ) );
+		editables.add( document.createElement( 'div' ) );
+
+		editables.current = editables.get( 1 );
+
+		expect( editables.current ).to.equal( editables.get( 1 ) );
+	} );
+
+	it( 'should point to the first available editable if it has been set to `null`', function() {
+		var editables = new EditableCollection();
+
+		editables.add( document.createElement( 'div' ) );
+		editables.add( document.createElement( 'div' ) );
+
+		editables.current = editables.get( 1 );
+		editables.current = null;
+
+		expect( editables.current ).to.equal( editables.get( 0 ) );
+	} );
+
+	it( 'should return `null` if not editable is available', function() {
+		var editables = new EditableCollection();
+
+		expect( editables.current ).to.be.null();
+	} );
+} );
+
+describe( 'add', function() {
+	it( 'should accept DOM node', function() {
+		var el = document.createElement( 'div' );
+
+		var editables = new EditableCollection();
+
+		editables.add( el );
+
+		expect( editables.get( 0 ) ).to.be.an.instanceof( Editable );
+		expect( editables.get( 0 ).element ).to.equal( el );
+	} );
+
+	it( 'should accept Editable instances', function() {
+		var el = document.createElement( 'div' );
+
+		var editables = new EditableCollection();
+		var editable = new Editable( el );
+
+		editables.add( editable );
+
+		expect( editables.get( 0 ) ).to.equal( editable );
+		expect( editables.get( 0 ).element ).to.equal( el );
+	} );
+} );

--- a/tests/editablecollection/editablecollection.js
+++ b/tests/editablecollection/editablecollection.js
@@ -17,6 +17,24 @@ before( function() {
 	Editable = modules.editable;
 } );
 
+describe( 'constructor', function() {
+	it( 'should have `parent` empty by default', function() {
+		var editables = new EditableCollection();
+
+		expect( editables.parent ).to.be.undefined();
+	} );
+
+	it( 'should set the `parent` property', function() {
+		var parentEl = document.createElement( 'div' );
+
+		var parentEditable = new Editable( parentEl );
+
+		var editables = new EditableCollection( parentEditable );
+
+		expect( editables.parent ).to.equal( parentEditable );
+	} );
+} );
+
 describe( 'current', function() {
 	it( 'should point to the first available editable by default', function() {
 		var el = document.createElement( 'div' );
@@ -80,5 +98,19 @@ describe( 'add', function() {
 
 		expect( editables.get( 0 ) ).to.equal( editable );
 		expect( editables.get( 0 ).element ).to.equal( el );
+	} );
+
+	it( 'should set the parent editable into items', function() {
+		var parentEl = document.createElement( 'div' );
+		var el = document.createElement( 'div' );
+
+		var parentEditable = new Editable( parentEl );
+
+		var editables = new EditableCollection( parentEditable );
+
+		var editable = new Editable( el );
+		editables.add( editable );
+
+		expect( editable.parent ).to.equal( parentEditable );
 	} );
 } );

--- a/tests/editor/creator.js
+++ b/tests/editor/creator.js
@@ -1,0 +1,97 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, beforeEach, sinon, document */
+
+'use strict';
+
+var modules = bender.amd.require( 'editor', 'editorconfig', 'plugin', 'promise' );
+
+var editor;
+var element;
+
+var creator, creator2;
+
+beforeEach( function() {
+	// Creator mocks.
+	creator = sinon.spy();
+	creator.prototype.create = sinon.spy();
+	creator.prototype.destroy = sinon.spy();
+
+	creator2 = sinon.spy();
+	creator2.prototype.create = sinon.spy();
+
+	return initEditor( {
+		plugins: 'testcreator'
+	} );
+} );
+
+function initEditor( config ) {
+	var Editor = modules.editor;
+
+	element = document.createElement( 'div' );
+	document.body.appendChild( element );
+
+	editor = new Editor( element, config );
+
+	return editor.init();
+}
+
+CKEDITOR.define( 'plugin!testcreator', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: function() {
+			this.editor.addCreator( 'test', creator );
+		}
+	} );
+} );
+
+CKEDITOR.define( 'plugin!testcreator2', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: function() {
+			this.editor.addCreator( 'test2', creator2 );
+		}
+	} );
+} );
+
+///////////////////
+
+describe( 'init', function() {
+	it( 'should instantiate the creator and call create()', function() {
+		// The creator constructor has been called.
+		sinon.assert.calledOnce( creator );
+		sinon.assert.calledWith( creator, editor );
+
+		// The create method has been called.
+		sinon.assert.calledOnce( creator.prototype.create );
+	} );
+
+	it( 'should instantiate any creator when more than one is available', function() {
+		initEditor( {
+			plugins: 'testcreator,testcreator2'
+		} );
+
+		expect( ( creator.called && creator2.callCount === 0 ) || ( creator2.called && creator.callCount === 0 ) )
+			.to.be.true();
+	} );
+
+	it( 'should throw error is the creator doesn\'t exist', function() {
+		var initPromise = initEditor( {
+			creator: 'bad',
+			plugins: 'testcreator'
+		} );
+
+		return initPromise.catch( function( error ) {
+			expect( error ).to.be.an.instanceof( Error );
+		} );
+	} );
+} );
+
+describe( 'destroy', function() {
+	it( 'should call "destroy" on the creator', function() {
+		return editor.destroy().then( function() {
+			sinon.assert.calledOnce( creator.prototype.destroy );
+		} );
+	} );
+} );

--- a/tests/editor/creator.js
+++ b/tests/editor/creator.js
@@ -34,7 +34,9 @@ function initEditor( config ) {
 	element = document.createElement( 'div' );
 	document.body.appendChild( element );
 
-	editor = new Editor( element, config );
+	editor = new Editor();
+
+	editor.config.set( config );
 
 	return editor.init();
 }

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -11,11 +11,13 @@ var modules = bender.amd.require( 'editor', 'editorconfig', 'promise' );
 
 var editor;
 var element;
+var elementInnerHTML = '<p>Test</p>';
 
 beforeEach( function() {
 	var Editor = modules.editor;
 
 	element = document.createElement( 'div' );
+	element.innerHTML = elementInnerHTML;
 	document.body.appendChild( element );
 
 	editor = new Editor( element );
@@ -51,6 +53,38 @@ describe( 'init', function() {
 
 		expect( editor.init() ).to.equal( promise );
 	} );
+
+	it( 'should set the element data into the editor', function() {
+		return editor.init().then( function() {
+			expect( editor.getData() ).to.equal( elementInnerHTML );
+		} );
+	} );
+
+	it( 'should set the element data into the editor (textarea)', function() {
+		var Editor = modules.editor;
+
+		var data = '<p>Textarea test</p>';
+
+		element = document.createElement( 'textarea' );
+		element.value = data;
+		document.body.appendChild( element );
+
+		editor = new Editor( element );
+
+		return editor.init().then( function() {
+			expect( editor.getData() ).to.equal( data );
+		} );
+	} );
+
+	it( 'should not set the element data into the editor if data is already set', function() {
+		var data = '<p>Another test</p>';
+
+		return editor.setData( data ).then( function() {
+			return editor.init().then( function() {
+				expect( editor.getData() ).to.equal( data );
+			} );
+		} );
+	} );
 } );
 
 describe( 'destroy', function() {
@@ -68,5 +102,59 @@ describe( 'destroy', function() {
 		return editor.destroy().then( function() {
 			expect( editor ).to.not.have.property( 'element' );
 		} );
+	} );
+} );
+
+describe( 'setData', function() {
+	it( 'should return a promise that resolves properly', function() {
+		var Promise = modules.promise;
+
+		var promise = editor.setData( '' );
+
+		expect( promise ).to.be.an.instanceof( Promise );
+
+		return promise;
+	} );
+
+	it( 'should set the editor data', function() {
+		var data = '<p>Test</p>';
+
+		return editor.setData( data ).then( function() {
+			expect( editor.getData() ).to.equal( data );
+		} );
+	} );
+} );
+
+describe( 'setData', function() {
+	it( 'should return a promise that resolves properly', function() {
+		var Promise = modules.promise;
+
+		var promise = editor.setData( '' );
+
+		expect( promise ).to.be.an.instanceof( Promise );
+
+		return promise;
+	} );
+
+	it( 'should set the editor data', function() {
+		var data = '<p>Another test</p>';
+
+		return editor.setData( data ).then( function() {
+			expect( editor.getData() ).to.equal( data );
+		} );
+	} );
+} );
+
+describe( 'getData', function() {
+	// This is mostly a dup for one of the `init` tests, but it is here for completness as there are no other useful
+	// tests for getData().
+	it( 'should get the editor data', function() {
+		return editor.init().then( function() {
+			expect( editor.getData() ).to.equal( elementInnerHTML );
+		} );
+	} );
+
+	it( 'should return an emtpy string if no data is available', function() {
+		expect( editor.getData() ).to.equal( '' );
 	} );
 } );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -96,6 +96,12 @@ describe( 'destroy', function() {
 			sinon.assert.called( spy );
 		} );
 	} );
+
+	it( 'should return the same promise for successive calls', function() {
+		var promise = editor.destroy();
+
+		expect( editor.destroy() ).to.equal( promise );
+	} );
 } );
 
 describe( 'setData', function() {

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -153,8 +153,4 @@ describe( 'getData', function() {
 			expect( editor.getData() ).to.equal( elementInnerHTML );
 		} );
 	} );
-
-	it( 'should return an emtpy string if no data is available', function() {
-		expect( editor.getData() ).to.equal( '' );
-	} );
 } );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -96,12 +96,6 @@ describe( 'destroy', function() {
 			sinon.assert.called( spy );
 		} );
 	} );
-
-	it( 'should undefine the "element" property', function() {
-		return editor.destroy().then( function() {
-			expect( editor ).to.not.have.property( 'element' );
-		} );
-	} );
 } );
 
 describe( 'setData', function() {

--- a/tests/editor/plugins.js
+++ b/tests/editor/plugins.js
@@ -22,7 +22,11 @@ function getEditor( config ) {
 
 	var Editor = modules.editor;
 
-	var editor = new Editor( element, config );
+	var editor = new Editor();
+
+	if ( config ) {
+		editor.config.set( config );
+	}
 
 	return editor;
 }

--- a/tests/editor/plugins.js
+++ b/tests/editor/plugins.js
@@ -1,0 +1,145 @@
+/**
+ * @license Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals describe, it, expect, beforeEach, sinon, document, setTimeout */
+
+'use strict';
+
+var modules = bender.amd.require( 'editor', 'plugin' );
+
+var editor;
+var element;
+
+beforeEach( function() {
+	editor = getEditor();
+} );
+
+function getEditor( config ) {
+	element = document.createElement( 'div' );
+	document.body.appendChild( element );
+
+	var Editor = modules.editor;
+
+	var editor = new Editor( element, config );
+
+	return editor;
+}
+
+// Define fake plugins to be used in tests.
+
+CKEDITOR.define( 'plugin!A', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: sinon.spy().named( 'A' )
+	} );
+} );
+
+CKEDITOR.define( 'plugin!B', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: sinon.spy().named( 'B' )
+	} );
+} );
+
+CKEDITOR.define( 'plugin!C', [ 'plugin', 'plugin!B' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: sinon.spy().named( 'C' )
+	} );
+} );
+
+CKEDITOR.define( 'plugin!D', [ 'plugin', 'plugin!C' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: sinon.spy().named( 'D' )
+	} );
+} );
+
+CKEDITOR.define( 'plugin!E', [ 'plugin' ], function( Plugin ) {
+	return Plugin.extend( {} );
+} );
+
+// Synchronous plugin that depends on an asynchronous one.
+CKEDITOR.define( 'plugin!F', [ 'plugin', 'plugin!async' ], function( Plugin ) {
+	return Plugin.extend( {
+		init: sinon.spy().named( 'F' )
+	} );
+} );
+
+var asyncSpy = sinon.spy().named( 'async-call-spy' );
+
+CKEDITOR.define( 'plugin!async', [ 'plugin', 'promise' ], function( Plugin, Promise ) {
+	return Plugin.extend( {
+		init: sinon.spy( function() {
+			return new Promise( function( resolve ) {
+				setTimeout( function() {
+					asyncSpy();
+					resolve();
+				}, 0 );
+			} );
+		} )
+	} );
+} );
+
+///////////////////
+
+describe( 'init', function() {
+	it( 'should fill `plugins`', function() {
+		var Plugin = modules.plugin;
+
+		editor = getEditor( {
+			plugins: 'A,B'
+		} );
+
+		expect( editor.plugins.length ).to.equal( 0 );
+
+		return editor.init().then( function() {
+			expect( editor.plugins.length ).to.equal( 2 );
+
+			expect( editor.plugins.get( 'A' ) ).to.be.an.instanceof( Plugin );
+			expect( editor.plugins.get( 'B' ) ).to.be.an.instanceof( Plugin );
+		} );
+	} );
+
+	it( 'should initialize plugins in the right order', function() {
+		editor = getEditor( {
+			plugins: 'A,D'
+		} );
+
+		return editor.init().then( function() {
+			sinon.assert.callOrder(
+				editor.plugins.get( 'A' ).init,
+				editor.plugins.get( 'B' ).init,
+				editor.plugins.get( 'C' ).init,
+				editor.plugins.get( 'D' ).init
+			);
+		} );
+	} );
+
+	it( 'should initialize plugins in the right order, waiting for asynchronous ones', function() {
+		editor = getEditor( {
+			plugins: 'A,F'
+		} );
+
+		return editor.init().then( function() {
+			sinon.assert.callOrder(
+				editor.plugins.get( 'A' ).init,
+				editor.plugins.get( 'async' ).init,
+				asyncSpy,	// This one is called with delay by the async init
+				editor.plugins.get( 'F' ).init
+			);
+		} );
+	} );
+
+	it( 'should not fail if loading a plugin that doesn\'t define init()', function() {
+		editor = getEditor( {
+			plugins: 'E'
+		} );
+
+		return editor.init();
+	} );
+} );
+
+describe( 'plugins', function() {
+	it( 'should be empty on new editor', function() {
+		expect( editor.plugins.length ).to.equal( 0 );
+	} );
+} );


### PR DESCRIPTION
Fixes #26.

A very initial version of the Classic Creator using the proposed API is being proposed separately at ckeditor/ckeditor5-plugin-classiccreator#2. Therefore a cross review is not a bad idea. For that intend, it is enough to add the following line in `package.json` at your local `ckeditor5` repo:

```
    "ckeditor5-plugin-classiccreator": "ckeditor/ckeditor5-plugin-classiccreator"
```

The above line will be added definitively once this PR is closed.

The code in this PR changed drastically in the middle of the road. It has been initially coded according to our very first design were we would have a single editable per editor instance. A working version of it is available at a3332e2. Then, we decided that supporting multiple editables per instance would be very interesting and so things have been refactored to support this. Therefore the reviewer will have a better experience by comparing this PR with master instead of checking commits individually.
