### PR TITLE
t/123: Model binding fails with as() when using custom attribute names.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -445,11 +445,9 @@ CKEDITOR.define( [ 'emittermixin', 'ckeditorerror', 'utils' ], ( EmitterMixin, C
 	 * @param {*} value The value of the attribute.
 	 */
 	function updateModelAttrs( chain, attrName, value ) {
-		const boundAttrs = getModelBindingsToCurrent( chain )[ attrName ];
+		let boundAttrs;
 
-		if ( !boundAttrs ) {
-			return;
-		} else if ( chain._callback ) {
+		if ( chain._callback ) {
 			// MODEL.bind( 'a' ).to( TOMODEL1, 'b1' )[ .to( TOMODELn, 'bn' ) ].as( callback )
 			//  \-> Collect specific attribute value in the boundTo.model (TOMODELn.bn).
 			//
@@ -464,7 +462,7 @@ CKEDITOR.define( [ 'emittermixin', 'ckeditorerror', 'utils' ], ( EmitterMixin, C
 				chain._bindAttrs[ 0 ],
 				chain._callback.apply( chain._bindModel, values )
 			);
-		} else {
+		} else if ( ( boundAttrs = getModelBindingsToCurrent( chain )[ attrName ] ) ) {
 			// MODEL.bind( 'a' ).to( TOMODEL1 )[ .to( TOMODELn ) ];
 			//  \-> If multiple .to() models but **no** .as( callback ), then the binding is invalid.
 			if ( !chain._callback && chain._boundTo.length > 1 ) {

--- a/tests/mvc/model/model.js
+++ b/tests/mvc/model/model.js
@@ -531,6 +531,26 @@ describe( 'Model', () => {
 						{ color: 'blackbrightyellow', year: undefined }
 					);
 				} );
+
+				it( 'should work for a single attribute #5', () => {
+					const vehicle = new Car();
+					const car1 = new Car( { hue: 'reds' } );
+					const car2 = new Car( { lightness: 'bright' } );
+
+					vehicle.bind( 'color' )
+						.to( car1, 'hue' )
+						.to( car2, 'lightness' )
+						.as( ( hue, lightness ) => hue + lightness );
+
+					assertBinding( vehicle,
+						{ color: car1.hue + car2.lightness, year: undefined },
+						[
+							[ car1, { hue: 'greens', year: 1930 } ],
+							[ car2, { lightness: 'dark', year: 1950 } ]
+						],
+						{ color: 'greensdark', year: undefined }
+					);
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes #123. It turned out that it is OK that `boundAttrs === undefined` when `chain._callback` is set (called `.to( ... ).as( _callback )`).