### PR TITLE
t/100: Range iteration refactoring.

### DIFF
--- a/src/treemodel/range.js
+++ b/src/treemodel/range.js
@@ -267,7 +267,7 @@ export default class Range {
 	 * `'ELEMENT_END'`, you can use {@link core.treeModel.TreeWalkerValue.previousPosition} as a position before the
 	 * item.
 	 *
-	 * @see {@link core.treeModel.TreeWalker}
+	 * @see core.treeModel.TreeWalker
 	 * @returns {Iterable.<core.treeModel.TreeWalkerValue>}
 	 */
 	*[ Symbol.iterator ]() {
@@ -277,12 +277,11 @@ export default class Range {
 	/**
 	 * Creates a {@link core.treeModel.TreeWalker} instance with this range as a boundary.
 	 *
-	 * @param {Object} options Object with configuration options.
-	 * @param {core.treeModel.Position} [options.startPosition] @see core.treeModel.TreeWalker#startPosition
-	 * @param {Boolean} [options.singleCharacters=false] @see core.treeModel.TreeWalker#singleCharacters
-	 * @param {Boolean} [options.shallow=false] @see core.treeModel.TreeWalker#shallow
-	 * @param {Boolean} [options.ignoreElementEnd=false] @see core.treeModel.TreeWalker#ignoreElementEnd
-	 * @constructor
+	 * @param {Object} options Object with configuration options. See {@link core.treeModel.TreeWalker}.
+	 * @param {core.treeModel.Position} [options.startPosition]
+	 * @param {Boolean} [options.singleCharacters=false]
+	 * @param {Boolean} [options.shallow=false]
+	 * @param {Boolean} [options.ignoreElementEnd=false]
 	 */
 	getWalker( options = {} ) {
 		options.boundaries = this;
@@ -297,10 +296,10 @@ export default class Range {
 	 * we enter into when iterating over this range. Note that it use {@link core.treeModel.TreeWalker} with the
 	 * {@link core.treeModel.TreeWalker#ignoreElementEnd ignoreElementEnd} option set to true.
 	 *
-	 * @param {Object} options Object with configuration options.
-	 * @param {core.treeModel.Position} [options.startPosition] @see core.treeModel.TreeWalker#startPosition
-	 * @param {Boolean} [options.singleCharacters=false] @see core.treeModel.TreeWalker#singleCharacters
-	 * @param {Boolean} [options.shallow=false] @see core.treeModel.TreeWalker#shallow
+	 * @param {Object} options Object with configuration options. See {@link core.treeModel.TreeWalker}.
+	 * @param {core.treeModel.Position} [options.startPosition]
+	 * @param {Boolean} [options.singleCharacters=false]
+	 * @param {Boolean} [options.shallow=false]
 	 * @returns {Iterable.<core.treeModel.Item>}
 	 */
 	*getItems( options = {} ) {
@@ -318,9 +317,9 @@ export default class Range {
 	 * Returns an iterator that iterates over all {@link core.treeModel.Position positions} that are boundaries or
 	 * contained in this range.
 	 *
-	 * @param {Object} options Object with configuration options.
-	 * @param {Boolean} [options.singleCharacters=false] @see core.treeModel.TreeWalker#singleCharacters
-	 * @param {Boolean} [options.shallow=false] @see core.treeModel.TreeWalker#shallow
+	 * @param {Object} options Object with configuration options. See {@link core.treeModel.TreeWalker}.
+	 * @param {Boolean} [options.singleCharacters=false]
+	 * @param {Boolean} [options.shallow=false]
 	 * @returns {Iterable.<core.treeModel.Position>}
 	 */
 	*getPositions( options = {} ) {

--- a/src/treemodel/treewalker.js
+++ b/src/treemodel/treewalker.js
@@ -52,7 +52,7 @@ export default class TreeWalker {
 		 *
 		 * If boundaries are not defined they are set before first and after last child of the root node.
 		 *
-		 * @type {core.treeModel.Range}
+		 * @member {core.treeModel.Range} core.treeModel.TreeWalker#boundaries
 		 */
 		this.boundaries = options.boundaries || null;
 
@@ -68,15 +68,15 @@ export default class TreeWalker {
 		 * End boundary cached for optimization purposes.
 		 *
 		 * @private
-		 * @type {core.treeModel.Element}
+		 * @member {core.treeModel.Element} core.treeModel.TreeWalker#_boundaryEndParent
 		 */
 		this._boundaryEndParent = this.boundaries ? this.boundaries.end.parent : null;
 
 		/**
-		 * Iterator position. This is alway static position, even if the initial position was a
+		 * Iterator position. This is always static position, even if the initial position was a
 		 * {@link core.treeModel.LivePosition live position}.
 		 *
-		 * @type {core.treeModel.Position}
+		 * @member {core.treeModel.Position} core.treeModel.TreeWalker#position
 		 */
 		this.position = options.startPosition ?
 			Position.createFromPosition( options.startPosition ) :
@@ -86,7 +86,7 @@ export default class TreeWalker {
 		 * Flag indicating whether all consecutive characters with the same attributes should be
 		 * returned as one {@link core.treeModel.CharacterProxy} (`true`) or one by one (`false`).
 		 *
-		 * @type {Boolean}
+		 * @member {Boolean} core.treeModel.TreeWalker#singleCharacters
 		 */
 		this.singleCharacters = !!options.singleCharacters;
 
@@ -94,7 +94,7 @@ export default class TreeWalker {
 		 * Flag indicating whether iterator should enter elements or not. If the iterator is shallow child nodes of any
 		 * iterated node will not be returned along with `ELEMENT_END` tag.
 		 *
-		 * @type {Boolean}
+		 * @member {Boolean} core.treeModel.TreeWalker#shallow
 		 */
 		this.shallow = !!options.shallow;
 
@@ -104,7 +104,7 @@ export default class TreeWalker {
 		 * be returned once, while if the option is `false` they might be returned twice:
 		 * for `'ELEMENT_START'` and `'ELEMENT_END'`.
 		 *
-		 * @type {Boolean}
+		 * @member {Boolean} core.treeModel.TreeWalker#ignoreElementEnd
 		 */
 		this.ignoreElementEnd = !!options.ignoreElementEnd;
 
@@ -112,7 +112,7 @@ export default class TreeWalker {
 		 * Parent of the most recently visited node. Cached for optimization purposes.
 		 *
 		 * @private
-		 * @type {core.treeModel.Element}
+		 * @member {core.treeModel.Element} core.treeModel.TreeWalker#_visitedParent
 		 */
 		this._visitedParent = this.position.parent;
 	}
@@ -141,8 +141,8 @@ export default class TreeWalker {
 			return { done: true };
 		}
 
-		// Parent can't be null so by comparing with boundaryParent we check if boundaryParent is set at all.
-		if ( parent == this._boundaryEndParent && position.offset == this.boundaries.end.offset ) {
+		// We reached the walker boundary.
+		if ( parent === this._boundaryEndParent && position.offset == this.boundaries.end.offset ) {
 			return { done: true };
 		}
 
@@ -182,6 +182,7 @@ export default class TreeWalker {
 				return formatReturnValue( 'TEXT', textFragment, previousPosition, position, charactersCount );
 			}
 		} else {
+			// `node` is not set, we reached the end of current `parent`.
 			position.path.pop();
 			position.offset++;
 			this.position = position;

--- a/src/treemodel/treewalker.js
+++ b/src/treemodel/treewalker.js
@@ -57,14 +57,6 @@ export default class TreeWalker {
 		this.boundaries = options.boundaries || null;
 
 		/**
-		 * Start boundary cached for optimization purposes.
-		 *
-		 * @private
-		 * @type {core.treeModel.Element}
-		 */
-		this._boundaryStartParent = this.boundaries ? this.boundaries.start.parent : null;
-
-		/**
 		 * End boundary cached for optimization purposes.
 		 *
 		 * @private
@@ -156,6 +148,7 @@ export default class TreeWalker {
 			} else {
 				position.offset++;
 			}
+
 			this.position = position;
 
 			return formatReturnValue( 'ELEMENT_START', node, previousPosition, position, 1 );

--- a/tests/treemodel/delta/attributedelta.js
+++ b/tests/treemodel/delta/attributedelta.js
@@ -135,7 +135,7 @@ describe( 'Batch', () => {
 
 			for ( let delta of batch.deltas ) {
 				for ( let operation of delta.operations ) {
-					count += getIteratorCount( operation.range.getItems( true ) );
+					count += getIteratorCount( operation.range.getItems( { singleCharacters: true } ) );
 				}
 			}
 
@@ -146,7 +146,9 @@ describe( 'Batch', () => {
 			// default: 111---111222---1112------
 			const range = Range.createFromElement( root );
 
-			return Array.from( range.getItems( true ) ).map( item => item.getAttribute( 'a' ) || '-' ).join( '' );
+			return Array.from( range.getItems( { singleCharacters: true } ) )
+				.map( item => item.getAttribute( 'a' ) || '-' )
+				.join( '' );
 		}
 
 		describe( 'setAttr', () => {


### PR DESCRIPTION
Fixes: https://github.com/ckeditor/ckeditor5-core/issues/100

Fixes changes described in the issue.

Also:
 - added `shallow` and `ignoreElementEnd` options to the `TreeWalker`, so you can run it in any configuration you need,
 - added `range.getWalker` method,
 - `range.getPositions`, `range.getItems` and `range.getWalker` methods get objects as a parameter,
 - removed `treewalker.previous` - it was unused and became more and more time consuming to maintain.