### PR TITLE
TreeView.addObserver should only allow a single observer of a type.

### DIFF
--- a/src/treeview/observer/domeventobserver.js
+++ b/src/treeview/observer/domeventobserver.js
@@ -37,23 +37,13 @@
  * @extends core.treeView.observer.Observer
  */
 export default class DomEventObserver {
-	/**
-	 * @inheritDoc
-	 */
-	init( treeView ) {
+	constructor( treeView ) {
 		/**
 		 * Reference to the {@link core.treeView.TreeView} object.
 		 *
 		 * @member {core.treeView.TreeView} core.treeView.observer.DomEventObserver#treeView
 		 */
 		this.treeView = treeView;
-
-		/**
-		 * State of the observer. If it is disabled not event should be fired.
-		 *
-		 * @member {Boolean} core.treeView.observer.DomEventObserver#isEnabled
-		 */
-		this.isEnabled = false;
 
 		/**
 		 * Type of the DOM event the observer should listen on.

--- a/src/treeview/observer/domeventobserver.js
+++ b/src/treeview/observer/domeventobserver.js
@@ -27,12 +27,6 @@
  *			}
  *		}
  *
- * Or:
- *
- *		const observer = new DomEventObserver();
- *		observer.domEventType = 'click';
- *		observer.onDomEvent = ( domEvt ) => observer.fire( 'click' );
- *
  * @memberOf core.treeView.observer
  * @extends core.treeView.observer.Observer
  */

--- a/src/treeview/observer/mutationobserver.js
+++ b/src/treeview/observer/mutationobserver.js
@@ -56,7 +56,7 @@ export default class MutationObserver extends Observer {
 		 * Observed DOM elements.
 		 *
 		 * @private
-		 * @member {HTMLElement[]} core.treeView.observer.MutationObserver#_domElements
+		 * @member {Array.<HTMLElement>} core.treeView.observer.MutationObserver#_domElements
 		 */
 		this._domElements = [];
 
@@ -105,7 +105,7 @@ export default class MutationObserver extends Observer {
 	 *
 	 * @protected
 	 * @method core.treeView.observer.MutationObserver#_onMutations
-	 * @param {Object[]} domMutations Array of native mutations.
+	 * @param {Array.<Object>} domMutations Array of native mutations.
 	 */
 	_onMutations( domMutations ) {
 		// Use　map and set for deduplication.
@@ -186,7 +186,7 @@ export default class MutationObserver extends Observer {
  * mutation, so all changes which should be applied, should be handled on this event.
  *
  * @event core.treeView.TreeView#mutations
- * @param {core.treeView.TreeView~MutatatedText[]|core.treeView.TreeView~MutatatedChildren[]} viewMutations
+ * @param {Array.<core.treeView.TreeView~MutatatedText|core.treeView.TreeView~MutatatedChildren>} viewMutations
  * Array of mutations.
  * For mutated texts it will be {@link core.treeView.TreeView~MutatatedText} and for mutated elements it will be
  * {@link core.treeView.TreeView~MutatatedElement}. You can recognize the type based on the `type` property.
@@ -216,6 +216,6 @@ export default class MutationObserver extends Observer {
  *
  * @property {String} type For child nodes mutations it is always 'children'.
  * @property {core.treeView.Element} node Parent of the mutated children.
- * @property {core.treeView.Node[]} oldChildren Old child nodes.
- * @property {core.treeView.Node[]} newChildren New child nodes.
+ * @property {Array.<core.treeView.Node>} oldChildren Old child nodes.
+ * @property {Array.<core.treeView.Node>} newChildren New child nodes.
  */

--- a/src/treeview/observer/mutationobserver.js
+++ b/src/treeview/observer/mutationobserver.js
@@ -22,12 +22,8 @@ import Observer from './observer.js';
  * @extends core.treeView.observer.Observer
  */
 export default class MutationObserver extends Observer {
-	/**
-	 * Mutation observer constructor. Note that most of the initialization is done in
-	 * {@link core.treeView.observer.MutationObserver#init} method.
-	 */
-	constructor() {
-		super();
+	constructor( treeView ) {
+		super( treeView );
 
 		/**
 		 * Native mutation observer config.
@@ -41,18 +37,6 @@ export default class MutationObserver extends Observer {
 			characterDataOldValue: true,
 			subtree: true
 		};
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	init( treeView ) {
-		/**
-		 * Reference to the {@link core.treeView.TreeView} object.
-		 *
-		 * @member {core.treeView.TreeView} core.treeView.observer.MutationObserver#treeView
-		 */
-		this.treeView = treeView;
 
 		/**
 		 * Reference to the {@link core.treeView.TreeView#domConverter}.
@@ -69,21 +53,27 @@ export default class MutationObserver extends Observer {
 		this.renderer = treeView.renderer;
 
 		/**
+		 * Observed DOM elements.
+		 *
+		 * @private
+		 * @member {HTMLElement[]} core.treeView.observer.MutationObserver#_domElements
+		 */
+		this._domElements = [];
+
+		/**
 		 * Native mutation observer.
 		 *
 		 * @private
-		 * @member {window.MutationObserver} core.treeView.observer.MutationObserver#_mutationObserver
+		 * @member {MutationObserver} core.treeView.observer.MutationObserver#_mutationObserver
 		 */
 		this._mutationObserver = new window.MutationObserver( this._onMutations.bind( this ) );
-
-		this.domElements = [];
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	observe( domElement ) {
-		this.domElements.push( domElement );
+		this._domElements.push( domElement );
 
 		if ( this.isEnabled ) {
 			this._mutationObserver.observe( domElement, this._config );
@@ -96,7 +86,7 @@ export default class MutationObserver extends Observer {
 	enable() {
 		this.isEnabled = true;
 
-		for ( let domElement of this.domElements ) {
+		for ( let domElement of this._domElements ) {
 			this._mutationObserver.observe( domElement, this._config );
 		}
 	}
@@ -115,7 +105,7 @@ export default class MutationObserver extends Observer {
 	 *
 	 * @protected
 	 * @method core.treeView.observer.MutationObserver#_onMutations
-	 * @param {Array.<Object>} domMutations Array of native mutations.
+	 * @param {Object[]} domMutations Array of native mutations.
 	 */
 	_onMutations( domMutations ) {
 		// Use　map and set for deduplication.
@@ -196,7 +186,7 @@ export default class MutationObserver extends Observer {
  * mutation, so all changes which should be applied, should be handled on this event.
  *
  * @event core.treeView.TreeView#mutations
- * @param {Array.<core.treeView.TreeView~MutatatedText|core.treeView.TreeView~MutatatedChildren>} viewMutations
+ * @param {core.treeView.TreeView~MutatatedText[]|core.treeView.TreeView~MutatatedChildren[]} viewMutations
  * Array of mutations.
  * For mutated texts it will be {@link core.treeView.TreeView~MutatatedText} and for mutated elements it will be
  * {@link core.treeView.TreeView~MutatatedElement}. You can recognize the type based on the `type` property.
@@ -226,6 +216,6 @@ export default class MutationObserver extends Observer {
  *
  * @property {String} type For child nodes mutations it is always 'children'.
  * @property {core.treeView.Element} node Parent of the mutated children.
- * @property {Array.<core.treeView.Node>} oldChildren Old child nodes.
- * @property {Array.<core.treeView.Node>} newChildren New child nodes.
+ * @property {core.treeView.Node[]} oldChildren Old child nodes.
+ * @property {core.treeView.Node[]} newChildren New child nodes.
  */

--- a/src/treeview/observer/observer.js
+++ b/src/treeview/observer/observer.js
@@ -14,12 +14,27 @@
  */
 export default class Observer {
 	/**
-	 * Inits the observer class, caches all needed {@link core.treeView.TreeView} properties.
-	 * After being inited, the observer will be {@link core.treeView.observer.Observer#enabled enabled}.
+	 * Creates an instance of the observer.
 	 *
-	 * @method core.treeView.observer.Observer#init
-	 * @param {core.treeView.TreeView}
+	 * @param {core.treeView.TreeView} treeView
 	 */
+	constructor( treeView ) {
+		/**
+		 * Reference to the {@link core.treeView.TreeView} object.
+		 *
+		 * @readonly
+		 * @member {core.treeView.TreeView} core.treeView.observer.Observer#treeView
+		 */
+		this.treeView = treeView;
+
+		/**
+		 * State of the observer. If it is disabled events will not be fired.
+		 *
+		 * @readonly
+		 * @member {Boolean} core.treeView.observer.Observer#isEnabled
+		 */
+		this.isEnabled = false;
+	}
 
 	/**
 	 * Enables the observer. This method is called when then observer is registered to the

--- a/tests/treeview/manual/clickobserver.js
+++ b/tests/treeview/manual/clickobserver.js
@@ -11,13 +11,15 @@ import TreeView from '/ckeditor5/core/treeview/treeview.js';
 import DomEventObserver from '/ckeditor5/core/treeview/observer/domeventobserver.js';
 
 const treeView = new TreeView();
+let observer1, observer2;
 
-class ClickObserver extends DomEventObserver {
-	constructor( id ) {
-		super();
+class ClickObserver1 extends DomEventObserver {
+	constructor( treeView ) {
+		super( treeView );
 
-		this.id = id;
+		this.id = 1;
 		this.domEventType = 'click';
+		observer1 = this;
 	}
 
 	onDomEvent( domEvt ) {
@@ -25,18 +27,29 @@ class ClickObserver extends DomEventObserver {
 	}
 }
 
-const observer1 = new ClickObserver( 1 );
-const observer2 = new ClickObserver( 2 );
+class ClickObserver2 extends DomEventObserver {
+	constructor( treeView ) {
+		super( treeView );
+
+		this.id = 2;
+		this.domEventType = 'click';
+		observer2 = this;
+	}
+
+	onDomEvent( domEvt ) {
+		this.fire( 'click', this.id, domEvt.target.id );
+	}
+}
 
 treeView.on( 'click', ( evt, eventId, elementId ) => console.log( 'click', eventId, elementId ) );
 document.getElementById( 'enable1' ).addEventListener( 'click', () => observer1.enable() );
 document.getElementById( 'disable1' ).addEventListener( 'click', () => observer1.disable() );
 
-// Random order
-treeView.addObserver( observer1 );
+// Random order.
+treeView.addObserver( ClickObserver1 );
 
 treeView.createRoot( document.getElementById( 'clickerA' ), 'clickerA' );
 
-treeView.addObserver( observer2 );
+treeView.addObserver( ClickObserver2 );
 
 treeView.createRoot( document.getElementById( 'clickerB' ), 'clickerB' );

--- a/tests/treeview/manual/mutationobserver.js
+++ b/tests/treeview/manual/mutationobserver.js
@@ -14,11 +14,10 @@ import MutationObserver from '/ckeditor5/core/treeview/observer/mutationobserver
 
 const treeView = new TreeView();
 treeView.createRoot( document.getElementById( 'editor' ), 'editor' );
-const mutationObserver = new MutationObserver();
 
 treeView.on( 'mutations', ( evt, mutations ) => console.log( mutations ) );
 
-treeView.addObserver( mutationObserver );
+treeView.addObserver( MutationObserver );
 
 treeView.viewRoots.get( 'editor' ).appendChildren( [
 	new Element( 'p', [], [ new Text( 'foo' ) ] ),

--- a/tests/treeview/manual/typing.js
+++ b/tests/treeview/manual/typing.js
@@ -18,7 +18,7 @@ treeView.createRoot( document.getElementById( 'editor' ), 'editor' );
 treeView.on( 'mutations', ( evt, mutations ) => console.log( mutations ) );
 treeView.on( 'mutations', handleTyping );
 
-treeView.addObserver( new MutationObserver() );
+treeView.addObserver( MutationObserver );
 
 treeView.viewRoots.get( 'editor' ).appendChildren( [ new Element( 'p', [], [ new Text( 'foo' ) ] ) ] );
 

--- a/tests/treeview/observer/domeventobserver.js
+++ b/tests/treeview/observer/domeventobserver.js
@@ -11,29 +11,31 @@ import DomEventObserver from '/ckeditor5/core/treeview/observer/domeventobserver
 import TreeView from '/ckeditor5/core/treeview/treeview.js';
 
 class TestObserver extends DomEventObserver {
-	constructor( id ) {
-		super();
-
-		this.id = id;
+	constructor( treeView ) {
+		super( treeView );
 
 		this.domEventType = 'click';
 	}
 
 	onDomEvent( domEvt ) {
-		this.fire( 'click', this.id, domEvt );
+		this.fire( 'click', 'foo', domEvt );
 	}
 }
 
 describe( 'DomEventObserver', () => {
-	it( 'should add event lister', () => {
-		const testObserver = new TestObserver( 'foo' );
+	let treeView;
+
+	beforeEach( () => {
+		treeView = new TreeView();
+	} );
+
+	it( 'should add event listener', () => {
 		const domElement = document.createElement( 'p' );
 		const domEvent = new MouseEvent( 'click' );
-		const treeView = new TreeView();
 		const evtSpy = sinon.spy();
 
 		treeView.createRoot( domElement, 'root' );
-		treeView.addObserver( testObserver );
+		treeView.addObserver( TestObserver );
 		treeView.on( 'click', evtSpy );
 
 		domElement.dispatchEvent( domEvent );
@@ -44,16 +46,15 @@ describe( 'DomEventObserver', () => {
 	} );
 
 	it( 'should not fire event if observer is disabled', () => {
-		const testObserver = new TestObserver( 'foo' );
 		const domElement = document.createElement( 'p' );
 		const domEvent = new MouseEvent( 'click' );
-		const treeView = new TreeView();
 		const evtSpy = sinon.spy();
 
 		treeView.createRoot( domElement, 'root' );
-		treeView.addObserver( testObserver );
+		treeView.addObserver( TestObserver );
 		treeView.on( 'click', evtSpy );
 
+		const testObserver = Array.from( treeView._observers )[ 0 ];
 		testObserver.disable();
 
 		domElement.dispatchEvent( domEvent );
@@ -61,16 +62,17 @@ describe( 'DomEventObserver', () => {
 		expect( evtSpy.called ).to.be.false;
 	} );
 
-	it( 'should be fire event if observer is disabled and re-enabled', () => {
-		const testObserver = new TestObserver( 'foo' );
+	it( 'should fire event if observer is disabled and re-enabled', () => {
 		const domElement = document.createElement( 'p' );
 		const domEvent = new MouseEvent( 'click' );
 		const treeView = new TreeView();
 		const evtSpy = sinon.spy();
 
 		treeView.createRoot( domElement, 'root' );
-		treeView.addObserver( testObserver );
+		treeView.addObserver( TestObserver );
 		treeView.on( 'click', evtSpy );
+
+		const testObserver = Array.from( treeView._observers )[ 0 ];
 
 		testObserver.disable();
 
@@ -87,11 +89,8 @@ describe( 'DomEventObserver', () => {
 
 	describe( 'fire', () => {
 		it( 'should do nothing if observer is disabled', () => {
-			const testObserver = new TestObserver();
-			const treeView = new TreeView();
+			const testObserver = new TestObserver( treeView );
 			const fireSpy = sinon.spy( treeView, 'fire' );
-
-			testObserver.init( treeView );
 
 			testObserver.disable();
 

--- a/tests/treeview/observer/mutationobserver.js
+++ b/tests/treeview/observer/mutationobserver.js
@@ -18,12 +18,13 @@ describe( 'MutationObserver', () => {
 	beforeEach( () => {
 		treeView = new TreeView();
 		domEditor = document.getElementById( 'editor' );
-		mutationObserver = new MutationObserver();
 		lastMutations = null;
 
 		treeView.createRoot( domEditor, 'editor' );
 
-		treeView.addObserver( mutationObserver );
+		treeView.addObserver( MutationObserver );
+		mutationObserver = Array.from( treeView._observers )[ 0 ];
+
 		treeView.on( 'mutations', ( evt, mutations ) => lastMutations = mutations );
 
 		viewRoot = treeView.viewRoots.get( 'editor' );


### PR DESCRIPTION
Fixes #272.

I also made couple of other improvements:

1. Got rid of `init()` and moved as much as I could to the base `Observer`. I was also thinking about `enable()` and `disable()`, but I was too lazy.
2. Made `MutObs._domElements` private because there's no reason for it to be public.
3. Made `TreeView._observers` protected, because the world should not have access to observer instances. A single observer could've been registered by multiple components so none of them should have access to what it registered.