### PR TITLE
T/250 History and other improvements in core for undo

### DIFF
--- a/src/treemodel/batch.js
+++ b/src/treemodel/batch.js
@@ -58,17 +58,12 @@ export default class Batch {
 	 * Adds delta to the Batch instance. All modification methods (insert, remove, split, etc.) use this method
 	 * to add created deltas.
 	 *
-	 * @fires {@link core.treeModel.Document#batch}
 	 * @param {core.treeModel.delta.Delta} delta Delta to add.
 	 * @return {core.treeModel.delta.Delta} Added delta.
 	 */
 	addDelta( delta ) {
 		delta.batch = this;
 		this.deltas.push( delta );
-
-		if ( this.deltas.length == 1 ) {
-			this.doc.fire( 'batch', this );
-		}
 
 		return delta;
 	}

--- a/src/treemodel/batch.js
+++ b/src/treemodel/batch.js
@@ -65,6 +65,10 @@ export default class Batch {
 		delta.batch = this;
 		this.deltas.push( delta );
 
+		if ( this.deltas.length == 1 ) {
+			this.doc.fire( 'batch', this );
+		}
+
 		return delta;
 	}
 }
@@ -87,11 +91,11 @@ export default class Batch {
  *			// Create operations which should be components of this delta.
  *			const operation = new InsertOperation( position, nodes, this.doc.version );
  *
+ *			// Add operation to the delta. It is important to add operation before applying it.
+ *			delta.addOperation( operation );
+ *
  *			// Remember to apply every operation, no magic, you need to do it manually.
  *			this.doc.applyOperation( operation );
- *
- *			// Add operation to the delta.
- *			delta.addOperation( operation );
  *
  *			// Add delta to the Batch instance.
  *			this.addDelta( delta );

--- a/src/treemodel/batch.js
+++ b/src/treemodel/batch.js
@@ -58,6 +58,7 @@ export default class Batch {
 	 * Adds delta to the Batch instance. All modification methods (insert, remove, split, etc.) use this method
 	 * to add created deltas.
 	 *
+	 * @fires {@link core.treeModel.Document#batch}
 	 * @param {core.treeModel.delta.Delta} delta Delta to add.
 	 * @return {core.treeModel.delta.Delta} Added delta.
 	 */

--- a/src/treemodel/delta/attributedelta.js
+++ b/src/treemodel/delta/attributedelta.js
@@ -154,8 +154,8 @@ function changeNode( doc, key, value, node ) {
 			operation = new AttributeOperation( range, key, previousValue, value, doc.version );
 		}
 
-		doc.applyOperation( operation );
 		delta.addOperation( operation );
+		doc.applyOperation( operation );
 	}
 
 	// It is expected that this method returns a delta.
@@ -206,8 +206,8 @@ function changeRange( doc, attributeKey, attributeValue, range ) {
 		let range = new Range( lastSplitPosition, position );
 		const operation = new AttributeOperation( range, attributeKey, attributeValueBefore, attributeValue, doc.version );
 
-		doc.applyOperation( operation );
 		delta.addOperation( operation );
+		doc.applyOperation( operation );
 	}
 
 	return delta;

--- a/src/treemodel/delta/attributedelta.js
+++ b/src/treemodel/delta/attributedelta.js
@@ -204,7 +204,7 @@ function changeRange( doc, attributeKey, attributeValue, range ) {
 
 	function addOperation() {
 		let range = new Range( lastSplitPosition, position );
-		const operation = new AttributeOperation( range, attributeKey, attributeValueBefore, attributeValue, doc.version );
+		const operation = new AttributeOperation( range, attributeKey, attributeValueBefore || null, attributeValue, doc.version );
 
 		delta.addOperation( operation );
 		doc.applyOperation( operation );

--- a/src/treemodel/delta/delta.js
+++ b/src/treemodel/delta/delta.js
@@ -43,7 +43,7 @@ export default class Delta {
 	 * are no operations in delta, returns `null`.
 	 *
 	 * @see core.treeModel.Document
-	 * @type {Number|null} Delta base version.
+	 * @type {Number|null}
 	 */
 	get baseVersion() {
 		if ( this.operations.length > 0 ) {

--- a/src/treemodel/delta/delta.js
+++ b/src/treemodel/delta/delta.js
@@ -39,6 +39,21 @@ export default class Delta {
 	}
 
 	/**
+	 * Returns delta base version which is equal to the base version of the first operation in delta. If there
+	 * are no operations in delta, returns `null`.
+	 *
+	 * @see core.treeModel.Document
+	 * @type {Number|null} Delta base version.
+	 */
+	get baseVersion() {
+		if ( this.operations.length > 0 ) {
+			return this.operations[ 0 ].baseVersion;
+		}
+
+		return null;
+	}
+
+	/**
 	 * A class that will be used when creating reversed delta.
 	 *
 	 * @private
@@ -67,7 +82,6 @@ export default class Delta {
 	 */
 	clone() {
 		let delta = new this.constructor();
-		delta.batch = this.batch;
 
 		for ( let op of this.operations ) {
 			delta.addOperation( op.clone() );
@@ -91,13 +105,14 @@ export default class Delta {
 		let delta = new this._reverseDeltaClass();
 
 		for ( let op of this.operations ) {
-			let reversedOp = op.getReversed();
-			reversedOp.baseVersion += this.operations.length - 1;
-
-			delta.addOperation( reversedOp );
+			delta.addOperation( op.getReversed() );
 		}
 
 		delta.operations.reverse();
+
+		for ( let i = 0; i < delta.operations.length; i++ ) {
+			delta.operations[ i ].baseVersion = this.operations[ this.operations.length - 1 ].baseVersion + i + 1;
+		}
 
 		return delta;
 	}

--- a/src/treemodel/delta/mergedelta.js
+++ b/src/treemodel/delta/mergedelta.js
@@ -93,6 +93,7 @@ register( 'merge', function( position ) {
 	const positionBefore = Position.createFromParentAndOffset( nodeBefore, nodeBefore.getChildCount() );
 
 	const move = new MoveOperation( positionAfter, nodeAfter.getChildCount(), positionBefore, this.doc.version );
+	move.isSticky = true;
 	delta.addOperation( move );
 	this.doc.applyOperation( move );
 

--- a/src/treemodel/delta/mergedelta.js
+++ b/src/treemodel/delta/mergedelta.js
@@ -93,12 +93,12 @@ register( 'merge', function( position ) {
 	const positionBefore = Position.createFromParentAndOffset( nodeBefore, nodeBefore.getChildCount() );
 
 	const move = new MoveOperation( positionAfter, nodeAfter.getChildCount(), positionBefore, this.doc.version );
-	this.doc.applyOperation( move );
 	delta.addOperation( move );
+	this.doc.applyOperation( move );
 
 	const remove = new RemoveOperation( position, 1, this.doc.version );
-	this.doc.applyOperation( remove );
 	delta.addOperation( remove );
+	this.doc.applyOperation( remove );
 
 	this.addDelta( delta );
 

--- a/src/treemodel/delta/movedelta.js
+++ b/src/treemodel/delta/movedelta.js
@@ -77,8 +77,8 @@ export default class MoveDelta extends Delta {
 
 function addMoveOperation( batch, delta, sourcePosition, howMany, targetPosition ) {
 	const operation = new MoveOperation( sourcePosition, howMany, targetPosition, batch.doc.version );
-	batch.doc.applyOperation( operation );
 	delta.addOperation( operation );
+	batch.doc.applyOperation( operation );
 }
 
 /**

--- a/src/treemodel/delta/removedelta.js
+++ b/src/treemodel/delta/removedelta.js
@@ -22,8 +22,8 @@ export default class RemoveDelta extends MoveDelta {}
 
 function addRemoveOperation( batch, delta, position, howMany ) {
 	const operation = new RemoveOperation( position, howMany, batch.doc.version );
-	batch.doc.applyOperation( operation );
 	delta.addOperation( operation );
+	batch.doc.applyOperation( operation );
 }
 
 /**

--- a/src/treemodel/delta/splitdelta.js
+++ b/src/treemodel/delta/splitdelta.js
@@ -108,6 +108,7 @@ register( 'split', function( position ) {
 		Position.createFromParentAndOffset( copy, 0 ),
 		this.doc.version
 	);
+	move.isSticky = true;
 
 	delta.addOperation( move );
 	this.doc.applyOperation( move );

--- a/src/treemodel/delta/splitdelta.js
+++ b/src/treemodel/delta/splitdelta.js
@@ -67,7 +67,7 @@ export default class SplitDelta extends Delta {
 	}
 
 	static get _priority() {
-		return 10;
+		return 5;
 	}
 }
 

--- a/src/treemodel/delta/unwrapdelta.js
+++ b/src/treemodel/delta/unwrapdelta.js
@@ -77,14 +77,14 @@ register( 'unwrap', function( element ) {
 	let sourcePosition = Position.createFromParentAndOffset( element, 0 );
 
 	const move = new MoveOperation( sourcePosition, element.getChildCount(), Position.createBefore( element ), this.doc.version );
-	this.doc.applyOperation( move );
 	delta.addOperation( move );
+	this.doc.applyOperation( move );
 
 	// Computing new position because we moved some nodes before `element`.
 	// If we would cache `Position.createBefore( element )` we remove wrong node.
 	const remove = new RemoveOperation( Position.createBefore( element ), 1, this.doc.version );
-	this.doc.applyOperation( remove );
 	delta.addOperation( remove );
+	this.doc.applyOperation( remove );
 
 	this.addDelta( delta );
 

--- a/src/treemodel/delta/unwrapdelta.js
+++ b/src/treemodel/delta/unwrapdelta.js
@@ -77,6 +77,7 @@ register( 'unwrap', function( element ) {
 	let sourcePosition = Position.createFromParentAndOffset( element, 0 );
 
 	const move = new MoveOperation( sourcePosition, element.getChildCount(), Position.createBefore( element ), this.doc.version );
+	move.isSticky = true;
 	delta.addOperation( move );
 	this.doc.applyOperation( move );
 

--- a/src/treemodel/delta/weakinsertdelta.js
+++ b/src/treemodel/delta/weakinsertdelta.js
@@ -45,8 +45,8 @@ register( 'weakInsert', function( position, nodes ) {
 	}
 
 	const operation = new InsertOperation( position, nodes, this.doc.version );
-	this.doc.applyOperation( operation );
 	delta.addOperation( operation );
+	this.doc.applyOperation( operation );
 
 	this.addDelta( delta );
 

--- a/src/treemodel/delta/wrapdelta.js
+++ b/src/treemodel/delta/wrapdelta.js
@@ -100,13 +100,13 @@ register( 'wrap', function( range, elementOrString ) {
 	const delta = new WrapDelta();
 
 	let insert = new InsertOperation( range.end, element, this.doc.version );
-	this.doc.applyOperation( insert );
 	delta.addOperation( insert );
+	this.doc.applyOperation( insert );
 
 	let targetPosition = Position.createFromParentAndOffset( element, 0 );
 	let move = new MoveOperation( range.start, range.end.offset - range.start.offset, targetPosition, this.doc.version );
-	this.doc.applyOperation( move );
 	delta.addOperation( move );
+	this.doc.applyOperation( move );
 
 	this.addDelta( delta );
 

--- a/src/treemodel/delta/wrapdelta.js
+++ b/src/treemodel/delta/wrapdelta.js
@@ -35,6 +35,27 @@ export default class WrapDelta extends Delta {
 	}
 
 	/**
+	 * How many nodes is wrapped by the delta or `null` if there are no operations in delta.
+	 *
+	 * @type {Number}
+	 */
+	get howMany() {
+		let range = this.range;
+
+		return range ? range.end.offset - range.start.offset : 0;
+	}
+
+	/**
+	 * Operation that inserts wrapping element or `null` if there are no operations in the delta.
+	 *
+	 * @protected
+	 * @type {core.treeModel.operation.InsertOperation|core.treeModel.operation.ReinsertOperation}
+	 */
+	get _insertOperation() {
+		return this.operations[ 0 ] || null;
+	}
+
+	/**
 	 * Operation that moves wrapped nodes to their new parent or `null` if there are no operations in the delta.
 	 *
 	 * @protected

--- a/src/treemodel/document.js
+++ b/src/treemodel/document.js
@@ -319,12 +319,6 @@ export default class Document {
 	 *
 	 * @event core.treeModel.Document#changesDone
 	 */
-
-	/**
-	 * Fired when a first delta is added to a batch. Can be treated as "new batch created" event.
-	 *
-	 * @event core.treeModel.Document#batch
-	 */
 }
 
 utils.mix( Document, EmitterMixin );

--- a/src/treemodel/document.js
+++ b/src/treemodel/document.js
@@ -11,6 +11,7 @@ import transformations from './delta/basic-transformations.js'; // jshint ignore
 
 import RootElement from './rootelement.js';
 import Batch from './batch.js';
+import History from './history.js';
 import Selection from './selection.js';
 import EmitterMixin from '../../utils/emittermixin.js';
 import CKEditorError from '../../utils/ckeditorerror.js';
@@ -93,6 +94,14 @@ export default class Document {
 
 		// Graveyard tree root. Document always have a graveyard root, which stores removed nodes.
 		this.createRoot( graveyardSymbol );
+
+		/**
+		 * Document's history.
+		 *
+		 * @readonly
+		 * @member {core.treeModel.History} core.treeModel.Document#history
+		 */
+		this.history = new History();
 	}
 
 	/**
@@ -130,6 +139,8 @@ export default class Document {
 		let changes = operation._execute();
 
 		this.version++;
+
+		this.history.addOperation( operation );
 
 		const batch = operation.delta && operation.delta.batch;
 		this.fire( 'change', operation.type, changes, batch );

--- a/src/treemodel/document.js
+++ b/src/treemodel/document.js
@@ -119,8 +119,7 @@ export default class Document {
 	 * {@link core.treeModel.operation.Operation operations}. To create operations in the simple way use the
 	 * {@link core.treeModel.Batch} API available via {@link core.treeModel.Document#batch} method.
 	 *
-	 * This method calls {@link core.treeModel.Document#change} event.
-	 *
+	 * @fires @link core.treeModel.Document#change
 	 * @param {core.treeModel.operation.Operation} operation Operation to be applied.
 	 */
 	applyOperation( operation ) {
@@ -199,7 +198,7 @@ export default class Document {
 	 *
 	 * When all queued changes are done {@link core.treeModel.Document#changesDone} event is fired.
 	 *
-	 * @fires {@link core.treeModel.Document#changesDone}
+	 * @fires @link core.treeModel.Document#changesDone
 	 * @param {Function} callback Callback to enqueue.
 	 */
 	enqueueChanges( callback ) {
@@ -319,6 +318,12 @@ export default class Document {
 	 * Fired when all queued document changes are done. See {@link core.treeModel.Document#enqueueChanges}.
 	 *
 	 * @event core.treeModel.Document#changesDone
+	 */
+
+	/**
+	 * Fired when a first delta is added to a batch. Can be treated as "new batch created" event.
+	 *
+	 * @event core.treeModel.Document#batch
 	 */
 }
 

--- a/src/treemodel/history.js
+++ b/src/treemodel/history.js
@@ -84,7 +84,7 @@ export default class History {
 	 * @param {core.treeModel.delta.Delta} delta Delta to update.
 	 * @returns {Array.<core.treeModel.delta.Delta>} Result of transformation which is an array containing one or more deltas.
 	 */
-	updateDelta( delta ) {
+	getTransformedDelta( delta ) {
 		if ( delta.baseVersion === this._nextHistoryPoint ) {
 			return [ delta ];
 		}

--- a/src/treemodel/history.js
+++ b/src/treemodel/history.js
@@ -1,0 +1,126 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+// Load all basic deltas and transformations, they register themselves, but they need to be imported somewhere.
+import deltas from './delta/basic-deltas.js';
+import transformations from './delta/basic-transformations.js';
+/*jshint unused: false*/
+
+import transform from './delta/transform.js';
+import CKEditorError from '../../utils/ckeditorerror.js';
+
+/**
+ * History keeps the track of all the deltas applied to the {@link core.treeModel.Document document} and provides
+ * utility tools to operate on the history. Most of times history is needed to transform a delta that has wrong
+ * {@link core.treeModel.delta.Delta#baseVersion} to a state where it can be applied to the document.
+ *
+ * @memberOf core.treeModel
+ */
+export default class History {
+	/**
+	 * Creates an empty History instance.
+	 */
+	constructor() {
+		/**
+		 * Deltas added to the history.
+		 *
+		 * @private
+		 * @member {Array.<core.treeModel.delta.Delta>} core.treeModel.History#_deltas
+		 */
+		this._deltas = [];
+
+		/**
+		 * Helper structure that maps added delta's base version to the index in {@link core.treeModel.History#_deltas}
+		 * at which the delta was added.
+		 *
+		 * @private
+		 * @member {Map} core.treeModel.History#_historyPoints
+		 */
+		this._historyPoints = new Map();
+	}
+
+	/**
+	 * Gets the number of base version which an up-to-date operation should have.
+	 *
+	 * @private
+	 * @type {Number}
+	 */
+	get _nextHistoryPoint() {
+		const lastDelta = this._deltas[ this._deltas.length - 1 ];
+
+		return lastDelta.baseVersion + lastDelta.operations.length;
+	}
+
+	/**
+	 * Adds an operation to the history.
+	 *
+	 * @param {core.treeModel.operation.Operation} operation Operation to add.
+	 */
+	addOperation( operation ) {
+		const delta = operation.delta;
+
+		// History cares about deltas not singular operations.
+		// Operations from a delta are added one by one, from first to last.
+		// Operations from one delta cannot be mixed with operations from other deltas.
+		// This all leads us to the conclusion that we could just save deltas history.
+		// What is more, we need to check only the last position in history to check if delta is already in the history.
+		if ( delta && this._deltas[ this._deltas.length - 1 ] !== delta ) {
+			const index = this._deltas.length;
+
+			this._deltas[ index ] = delta;
+			this._historyPoints.set( delta.baseVersion, index );
+		}
+	}
+
+	/**
+	 * Transforms out-dated delta by all deltas that were added to the history since the given delta's base version. In other
+	 * words, it makes the delta up-to-date with the history. The transformed delta(s) is (are) ready to be applied
+	 * to the {@link core.treeModel.Document document}.
+	 *
+	 * @param {core.treeModel.delta.Delta} delta Delta to update.
+	 * @returns {Array.<core.treeModel.delta.Delta>} Result of transformation which is an array containing one or more deltas.
+	 */
+	updateDelta( delta ) {
+		if ( delta.baseVersion === this._nextHistoryPoint ) {
+			return [ delta ];
+		}
+
+		let index = this._historyPoints.get( delta.baseVersion );
+
+		if ( index === undefined ) {
+			throw new CKEditorError( 'history-wrong-version: Cannot retrieve point in history that is a base for given delta.' );
+		}
+
+		let transformed = [ delta ];
+
+		while ( index < this._deltas.length ) {
+			const historyDelta = this._deltas[ index ];
+			let allResults = [];
+
+			for ( let deltaToTransform of transformed ) {
+				const transformedDelta = History._transform( deltaToTransform, historyDelta );
+				allResults = allResults.concat( transformedDelta );
+			}
+
+			transformed = allResults;
+			index++;
+		}
+
+		return transformed;
+	}
+
+	/**
+	 * Transforms given delta by another given delta.
+	 *
+	 * @private
+	 * @param {core.treeModel.delta.Delta} toTransform Delta to be transformed.
+	 * @param {core.treeModel.delta.Delta} transformBy Delta to transform by.
+	 */
+	static _transform( toTransform, transformBy ) {
+		return transform( toTransform, transformBy, false );
+	}
+}

--- a/src/treemodel/history.js
+++ b/src/treemodel/history.js
@@ -114,9 +114,9 @@ export default class History {
 	}
 
 	/**
-	 * Transforms given delta by another given delta.
+	 * Transforms given delta by another given delta. Exposed for testing purposes.
 	 *
-	 * @private
+	 * @protected
 	 * @param {core.treeModel.delta.Delta} toTransform Delta to be transformed.
 	 * @param {core.treeModel.delta.Delta} transformBy Delta to transform by.
 	 */

--- a/src/treemodel/operation/reinsertoperation.js
+++ b/src/treemodel/operation/reinsertoperation.js
@@ -21,18 +21,21 @@ import RemoveOperation from './removeoperation.js';
  * @extends core.treeModel.operation.Operation
  */
 export default class ReinsertOperation extends MoveOperation {
-	/**
-	 * @returns {core.treeModel.operation.RemoveOperation}
-	 */
-	getReversed() {
-		return new RemoveOperation( this.targetPosition, this.howMany, this.baseVersion + 1 );
+	get position() {
+		return this.targetPosition;
+	}
+
+	set position( pos ) {
+		this.targetPosition = pos;
 	}
 
 	get type() {
 		return 'reinsert';
 	}
-
-	get isSticky() {
-		return false;
+	/**
+	 * @returns {core.treeModel.operation.RemoveOperation}
+	 */
+	getReversed() {
+		return new RemoveOperation( this.targetPosition, this.howMany, this.baseVersion + 1 );
 	}
 }

--- a/src/treemodel/operation/reinsertoperation.js
+++ b/src/treemodel/operation/reinsertoperation.js
@@ -21,6 +21,11 @@ import RemoveOperation from './removeoperation.js';
  * @extends core.treeModel.operation.Operation
  */
 export default class ReinsertOperation extends MoveOperation {
+	/**
+	 * Position where re-inserted node will be inserted.
+	 *
+	 * @type {core.treeModel.Position}
+	 */
 	get position() {
 		return this.targetPosition;
 	}
@@ -32,6 +37,7 @@ export default class ReinsertOperation extends MoveOperation {
 	get type() {
 		return 'reinsert';
 	}
+
 	/**
 	 * @returns {core.treeModel.operation.RemoveOperation}
 	 */

--- a/src/treemodel/operation/removeoperation.js
+++ b/src/treemodel/operation/removeoperation.js
@@ -35,10 +35,6 @@ export default class RemoveOperation extends MoveOperation {
 		return 'remove';
 	}
 
-	get isSticky() {
-		return false;
-	}
-
 	/**
 	 * @returns {core.treeModel.operation.ReinsertOperation}
 	 */

--- a/tests/treemodel/batch.js
+++ b/tests/treemodel/batch.js
@@ -68,21 +68,5 @@ describe( 'Batch', () => {
 			expect( batch.deltas[ 0 ] ).to.equal( deltaA );
 			expect( batch.deltas[ 1 ] ).to.equal( deltaB );
 		} );
-
-		it( 'should fire batch event on it\'s document when first delta is added to the batch', () => {
-			const doc = new Document();
-			const batch = new Batch( doc );
-			const spy = sinon.spy();
-
-			doc.on( 'batch', spy );
-
-			batch.addDelta( new Delta() );
-
-			expect( spy.calledOnce ).to.be.true;
-
-			batch.addDelta( new Delta() );
-
-			expect( spy.calledOnce ).to.be.true;
-		} );
 	} );
 } );

--- a/tests/treemodel/delta/transform/_utils/utils.js
+++ b/tests/treemodel/delta/transform/_utils/utils.js
@@ -59,7 +59,10 @@ export function getMergeDelta( position, howManyInPrev, howManyInNext, version )
 	targetPosition.offset--;
 	targetPosition.path.push( howManyInPrev );
 
-	delta.addOperation( new MoveOperation( sourcePosition, howManyInNext, targetPosition, version ) );
+	let move = new MoveOperation( sourcePosition, howManyInNext, targetPosition, version );
+	move.isSticky = true;
+
+	delta.addOperation( move );
 	delta.addOperation( new RemoveOperation( position, 1, version + 1 ) );
 
 	return delta;
@@ -94,7 +97,11 @@ export function getSplitDelta( position, nodeCopy, howManyMove, version ) {
 	targetPosition.path.push( 0 );
 
 	delta.addOperation( new InsertOperation( insertPosition, [ nodeCopy ], version ) );
-	delta.addOperation( new MoveOperation( position, howManyMove, targetPosition, version + 1 ) );
+
+	let move = new MoveOperation( position, howManyMove, targetPosition, version + 1 );
+	move.isSticky = true;
+
+	delta.addOperation( move );
 
 	return delta;
 }
@@ -121,6 +128,7 @@ export function getUnwrapDelta( positionBefore, howManyChildren, version ) {
 	sourcePosition.path.push( 0 );
 
 	let move = new MoveOperation( sourcePosition, howManyChildren, positionBefore, version );
+	move.isSticky = true;
 
 	let removePosition = Position.createFromPosition( positionBefore );
 	removePosition.offset += howManyChildren;

--- a/tests/treemodel/delta/transform/delta.js
+++ b/tests/treemodel/delta/transform/delta.js
@@ -21,7 +21,7 @@ import {
 	getFilledDocument,
 } from '/tests/core/treemodel/delta/transform/_utils/utils.js';
 
-describe( 'transform', () => {
+describe( 'Delta', () => {
 	let doc, root, baseVersion;
 
 	beforeEach( () => {
@@ -30,7 +30,19 @@ describe( 'transform', () => {
 		baseVersion = doc.version;
 	} );
 
-	it( 'should transform delta by transforming it\'s operations', () => {
+	it( 'should have baseVersion property, equal to the baseVersion of first operation in Delta or null', () => {
+		let deltaA = new Delta();
+
+		expect( deltaA.baseVersion ).to.be.null;
+
+		let version = 5;
+
+		deltaA.addOperation( new MoveOperation( new Position( root, [ 1, 2, 3 ] ), 4, new Position( root, [ 4, 0 ] ), version ) );
+
+		expect( deltaA.baseVersion ).to.equal( 5 );
+	} );
+
+	it( 'should be transformable by another Delta', () => {
 		let deltaA = new Delta();
 		let deltaB = new Delta();
 

--- a/tests/treemodel/delta/transform/splitdelta.js
+++ b/tests/treemodel/delta/transform/splitdelta.js
@@ -273,12 +273,51 @@ describe( 'transform', () => {
 				expect( nodesAndText ).to.equal( 'PaEbcfoEobarxyzP' );
 			} );
 
+			it( 'split position is before wrapped nodes', () => {
+				let wrapRange = new Range( new Position( root, [ 3, 3, 3, 5 ] ), new Position( root, [ 3, 3, 3, 7 ] ) );
+				let wrapElement = new Element( 'E' );
+				let wrapDelta = getWrapDelta( wrapRange, wrapElement, baseVersion );
+
+				let transformed = transform( splitDelta, wrapDelta );
+
+				expect( transformed.length ).to.equal( 1 );
+
+				baseVersion = wrapDelta.operations.length;
+
+				expectDelta( transformed[ 0 ], {
+					type: SplitDelta,
+					operations: [
+						{
+							type: InsertOperation,
+							position: new Position( root, [ 3, 3, 4 ] ),
+							baseVersion: baseVersion
+						},
+						{
+							type: MoveOperation,
+							sourcePosition: new Position( root, [ 3, 3, 3, 3 ] ),
+							howMany: 8,
+							targetPosition: new Position( root, [ 3, 3, 4, 0 ] ),
+							baseVersion: baseVersion + 1
+						}
+					]
+				} );
+
+				// Test if deltas do what they should after applying transformed delta.
+				applyDelta( wrapDelta, doc );
+				applyDelta( transformed[ 0 ], doc );
+
+				let nodesAndText = getNodesAndText( Range.createFromPositionAndShift( new Position( root, [ 3, 3, 3 ] ), 2 ) );
+
+				// WrapDelta and SplitDelta are correctly applied.
+				expect( nodesAndText ).to.equal( 'PabcPPfoEobEarxyzP' );
+			} );
+
 			it( 'split position is inside wrapped node', () => {
 				let wrapRange = new Range( new Position( root, [ 3, 3, 2 ] ), new Position( root, [ 3, 3, 4 ] ) );
 				let wrapElement = new Element( 'E' );
 				let wrapDelta = getWrapDelta( wrapRange, wrapElement, baseVersion );
 
-				let transformed = transform( splitDelta, wrapDelta, true );
+				let transformed = transform( splitDelta, wrapDelta );
 
 				expect( transformed.length ).to.equal( 1 );
 

--- a/tests/treemodel/delta/wrapdelta.js
+++ b/tests/treemodel/delta/wrapdelta.js
@@ -124,6 +124,21 @@ describe( 'WrapDelta', () => {
 		} );
 	} );
 
+	describe( 'howMany', () => {
+		it( 'should be equal to 0 if there are no operations in delta', () => {
+			expect( wrapDelta.howMany ).to.equal( 0 );
+		} );
+
+		it( 'should be equal to the number of wrapped elements', () => {
+			let howMany = 5;
+
+			wrapDelta.operations.push( new InsertOperation( new Position( root, [ 1, 6 ] ), 1 ) );
+			wrapDelta.operations.push( new MoveOperation( new Position( root, [ 1, 1 ] ), howMany, new Position( root, [ 1, 6, 0 ] ) ) );
+
+			expect( wrapDelta.howMany ).to.equal( 5 );
+		} );
+	} );
+
 	describe( 'getReversed', () => {
 		it( 'should return empty UnwrapDelta if there are no operations in delta', () => {
 			let reversed = wrapDelta.getReversed();
@@ -149,6 +164,21 @@ describe( 'WrapDelta', () => {
 			expect( reversed.operations[ 1 ] ).to.be.instanceof( RemoveOperation );
 			expect( reversed.operations[ 1 ].sourcePosition.path ).to.deep.equal( [ 1, 6 ] );
 			expect( reversed.operations[ 1 ].howMany ).to.equal( 1 );
+		} );
+	} );
+
+	describe( '_insertOperation', () => {
+		it( 'should be null if there are no operations in the delta', () => {
+			expect( wrapDelta._insertOperation ).to.be.null;
+		} );
+
+		it( 'should be equal to the first operation in the delta', () => {
+			let insertOperation = new InsertOperation( new Position( root, [ 1, 6 ] ), 1 );
+
+			wrapDelta.operations.push( insertOperation );
+			wrapDelta.operations.push( new MoveOperation( new Position( root, [ 1, 1 ] ), 5, new Position( root, [ 1, 6, 0 ] ) ) );
+
+			expect( wrapDelta._insertOperation ).to.equal( insertOperation );
 		} );
 	} );
 } );

--- a/tests/treemodel/history.js
+++ b/tests/treemodel/history.js
@@ -78,7 +78,7 @@ describe( 'History', () => {
 		} );
 	} );
 
-	describe( 'updateDelta', () => {
+	describe( 'getTransformedDelta', () => {
 		it( 'should transform given delta by deltas from history which were applied since the baseVersion of given delta', () => {
 			sinon.spy( History, '_transform' );
 
@@ -104,7 +104,7 @@ describe( 'History', () => {
 
 			// `deltaX` bases on the same history point as `deltaB` -- so it already acknowledges `deltaA` existence.
 			// It should be transformed by `deltaB` and all following deltas (`deltaC` and `deltaD`).
-			history.updateDelta( deltaX );
+			history.getTransformedDelta( deltaX );
 
 			// `deltaX` was not transformed by `deltaA`.
 			expect( History._transform.calledWithExactly( deltaX, deltaA ) ).to.be.false;
@@ -126,7 +126,7 @@ describe( 'History', () => {
 
 			history.addOperation( deltaA.operations[ 0 ] );
 
-			let result = history.updateDelta( deltaB );
+			let result = history.getTransformedDelta( deltaB );
 
 			expect( result.length ).to.equal( 1 );
 			expect( result[ 0 ] ).to.equal( deltaB );
@@ -147,7 +147,7 @@ describe( 'History', () => {
 			deltaB.addOperation( new NoOperation( 1 ) );
 
 			expect( () => {
-				history.updateDelta( deltaB );
+				history.getTransformedDelta( deltaB );
 			} ).to.throw( CKEditorError, /history-wrong-version/ );
 		} );
 	} );

--- a/tests/treemodel/history.js
+++ b/tests/treemodel/history.js
@@ -1,0 +1,154 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import History from '/ckeditor5/core/treemodel/history.js';
+import Delta from '/ckeditor5/core/treemodel/delta/delta.js';
+import NoOperation from '/ckeditor5/core/treemodel/operation/nooperation.js';
+import CKEditorError from '/ckeditor5/utils/ckeditorerror.js';
+
+describe( 'History', () => {
+	let history;
+
+	beforeEach( () => {
+		history = new History();
+	} );
+
+	describe( 'constructor', () => {
+		it( 'should create an empty History instance', () => {
+			expect( history._deltas.length ).to.equal( 0 );
+			expect( history._historyPoints.size ).to.equal( 0 );
+		} );
+	} );
+
+	describe( 'addOperation', () => {
+		it( 'should save delta containing passed operation in the history', () => {
+			let delta = new Delta();
+			let operation = new NoOperation( 0 );
+
+			delta.addOperation( operation );
+			history.addOperation( operation );
+
+			expect( history._deltas.length ).to.equal( 1 );
+			expect( history._deltas[ 0 ] ).to.equal( delta );
+		} );
+
+		it( 'should save each delta only once', () => {
+			let delta = new Delta();
+
+			delta.addOperation( new NoOperation( 0 ) );
+			delta.addOperation( new NoOperation( 1 ) );
+			delta.addOperation( new NoOperation( 2 ) );
+
+			for ( let operation of delta.operations ) {
+				history.addOperation( operation );
+			}
+
+			expect( history._deltas.length ).to.equal( 1 );
+			expect( history._deltas[ 0 ] ).to.equal( delta );
+		} );
+
+		it( 'should save multiple deltas and keep their order', () => {
+			let deltaA = new Delta();
+			let deltaB = new Delta();
+			let deltaC = new Delta();
+
+			let deltas = [ deltaA, deltaB, deltaC ];
+
+			let i = 0;
+
+			for ( let delta of deltas ) {
+				delta.addOperation( new NoOperation( i++ ) );
+				delta.addOperation( new NoOperation( i++ ) );
+			}
+
+			for ( let delta of deltas ) {
+				for ( let operation of delta.operations ) {
+					history.addOperation( operation );
+				}
+			}
+
+			expect( history._deltas.length ).to.equal( 3 );
+			expect( history._deltas[ 0 ] ).to.equal( deltaA );
+			expect( history._deltas[ 1 ] ).to.equal( deltaB );
+			expect( history._deltas[ 2 ] ).to.equal( deltaC );
+		} );
+	} );
+
+	describe( 'updateDelta', () => {
+		it( 'should transform given delta by deltas from history which were applied since the baseVersion of given delta', () => {
+			sinon.spy( History, '_transform' );
+
+			let deltaA = new Delta();
+			deltaA.addOperation( new NoOperation( 0 ) );
+
+			let deltaB = new Delta();
+			deltaB.addOperation( new NoOperation( 1 ) );
+
+			let deltaC = new Delta();
+			deltaC.addOperation( new NoOperation( 2 ) );
+
+			let deltaD = new Delta();
+			deltaD.addOperation( new NoOperation( 3 ) );
+
+			let deltaX = new Delta();
+			deltaX.addOperation( new NoOperation( 1 ) );
+
+			history.addOperation( deltaA.operations[ 0 ] );
+			history.addOperation( deltaB.operations[ 0 ] );
+			history.addOperation( deltaC.operations[ 0 ] );
+			history.addOperation( deltaD.operations[ 0 ] );
+
+			// `deltaX` bases on the same history point as `deltaB` -- so it already acknowledges `deltaA` existence.
+			// It should be transformed by `deltaB` and all following deltas (`deltaC` and `deltaD`).
+			history.updateDelta( deltaX );
+
+			// `deltaX` was not transformed by `deltaA`.
+			expect( History._transform.calledWithExactly( deltaX, deltaA ) ).to.be.false;
+
+			expect( History._transform.calledWithExactly( deltaX, deltaB ) ).to.be.true;
+			// We can't do exact call matching because after first transformation, what we are further transforming
+			// is no longer `deltaX` but a result of transforming `deltaX` and `deltaB`.
+			expect( History._transform.calledWithExactly( sinon.match.instanceOf( Delta ), deltaC ) ).to.be.true;
+			expect( History._transform.calledWithExactly( sinon.match.instanceOf( Delta ), deltaD ) ).to.be.true;
+		} );
+
+		it( 'should not transform given delta if it bases on current version of history', () => {
+			let deltaA = new Delta();
+			deltaA.addOperation( new NoOperation( 0 ) );
+
+			let deltaB = new Delta();
+			let opB = new NoOperation( 1 );
+			deltaB.addOperation( opB );
+
+			history.addOperation( deltaA.operations[ 0 ] );
+
+			let result = history.updateDelta( deltaB );
+
+			expect( result.length ).to.equal( 1 );
+			expect( result[ 0 ] ).to.equal( deltaB );
+			expect( result[ 0 ].operations[ 0 ] ).to.equal( opB );
+		} );
+
+		it( 'should throw if given delta bases on an incorrect version of history', () => {
+			let deltaA = new Delta();
+			deltaA.addOperation( new NoOperation( 0 ) );
+			deltaA.addOperation( new NoOperation( 1 ) );
+
+			history.addOperation( deltaA.operations[ 0 ] );
+			history.addOperation( deltaA.operations[ 1 ] );
+
+			let deltaB = new Delta();
+			// Wrong base version - should be either 0 or 2, operation can't be based on an operation that is
+			// in the middle of other delta, because deltas are atomic, not dividable structures.
+			deltaB.addOperation( new NoOperation( 1 ) );
+
+			expect( () => {
+				history.updateDelta( deltaB );
+			} ).to.throw( CKEditorError, /history-wrong-version/ );
+		} );
+	} );
+} );

--- a/tests/treemodel/operation/moveoperation.js
+++ b/tests/treemodel/operation/moveoperation.js
@@ -40,7 +40,7 @@ describe( 'MoveOperation', () => {
 			doc.version
 		);
 
-		expect( op.isSticky ).to.be.true;
+		expect( op.isSticky ).to.be.false;
 	} );
 
 	it( 'should move from one node to another', () => {

--- a/tests/treemodel/operation/reinsertoperation.js
+++ b/tests/treemodel/operation/reinsertoperation.js
@@ -32,6 +32,14 @@ describe( 'ReinsertOperation', () => {
 		);
 	} );
 
+	it( 'should have position property equal to the position where node will be reinserted', () => {
+		expect( operation.position.isEqual( rootPosition ) ).to.be.true;
+
+		// Setting also works:
+		operation.position = new Position( root, [ 1 ] );
+		expect( operation.position.isEqual( new Position( root, [ 1 ] ) ) ).to.be.true;
+	} );
+
 	it( 'should have proper type', () => {
 		expect( operation.type ).to.equal( 'reinsert' );
 	} );

--- a/tests/treemodel/operation/transform.js
+++ b/tests/treemodel/operation/transform.js
@@ -1713,12 +1713,27 @@ describe( 'transform', () => {
 				expectOperation( transOp[ 0 ], expected );
 			} );
 
-			it( 'target at offset same as range end boundary: expand range', () => {
+			it( 'target at offset same as range end boundary: no operation update', () => {
 				let transformBy = new InsertOperation(
 					new Position( root, [ 2, 2, 6 ] ),
 					[ nodeA, nodeB ],
 					baseVersion
 				);
+
+				let transOp = transform( op, transformBy );
+
+				expect( transOp.length ).to.equal( 1 );
+				expectOperation( transOp[ 0 ], expected );
+			} );
+
+			it( 'target at offset same as range end boundary (sticky move): expand range', () => {
+				let transformBy = new InsertOperation(
+					new Position( root, [ 2, 2, 6 ] ),
+					[ nodeA, nodeB ],
+					baseVersion
+				);
+
+				op.isSticky = true;
 
 				let transOp = transform( op, transformBy );
 
@@ -2035,7 +2050,7 @@ describe( 'transform', () => {
 				expectOperation( transOp[ 0 ], expected );
 			} );
 
-			it( 'target at start boundary of transforming move range: expand move range', () => {
+			it( 'target at start boundary of transforming move range: increment source offset', () => {
 				let transformBy = new MoveOperation(
 					new Position( root, [ 4, 1, 0 ] ),
 					2,
@@ -2047,18 +2062,53 @@ describe( 'transform', () => {
 
 				expect( transOp.length ).to.equal( 1 );
 
+				expected.sourcePosition.offset = 6;
+
+				expectOperation( transOp[ 0 ], expected );
+			} );
+
+			it( 'target at start boundary of transforming move range (sticky move): expand move range', () => {
+				let transformBy = new MoveOperation(
+					new Position( root, [ 4, 1, 0 ] ),
+					2,
+					new Position( root, [ 2, 2, 4 ] ),
+					baseVersion
+				);
+
+				op.isSticky = true;
+
+				let transOp = transform( op, transformBy );
+
+				expect( transOp.length ).to.equal( 1 );
+
 				expected.howMany = 4;
 
 				expectOperation( transOp[ 0 ], expected );
 			} );
 
-			it( 'target at end boundary of transforming move range: expand move range', () => {
+			it( 'target at end boundary of transforming move range: no operation update', () => {
 				let transformBy = new MoveOperation(
 					new Position( root, [ 4, 1, 0 ] ),
 					2,
 					new Position( root, [ 2, 2, 6 ] ),
 					baseVersion
 				);
+
+				let transOp = transform( op, transformBy );
+
+				expect( transOp.length ).to.equal( 1 );
+				expectOperation( transOp[ 0 ], expected );
+			} );
+
+			it( 'target at end boundary of transforming move range (sticky move): expand move range', () => {
+				let transformBy = new MoveOperation(
+					new Position( root, [ 4, 1, 0 ] ),
+					2,
+					new Position( root, [ 2, 2, 6 ] ),
+					baseVersion
+				);
+
+				op.isSticky = true;
 
 				let transOp = transform( op, transformBy );
 


### PR DESCRIPTION
This PR introduces improvements done to core repository that are connected with undo feature:
* `core.treeModel.History` class
* `core.treeModel.Document#batch` event
* multiple fixes in deltas, operations and OT.

There are two doubts I have about the code:
* Maybe `core.treeModel.Document#version` should be moved to `History` class? OTOH, right now `History` doesn't know anything about `Document`. But it feels natural to have that property there. I even had to implement `_nextHistoryPoint`...
* Placement of "new batch event". There are many possibilities to handle this problem:
 * leave it in `Batch.addDelta`
 * move it to `Batch` constructor
 * move it to `Document#batch`
 * move it to `Document#applyOperation` but then we need a registry for batches that we already sent an event for
 * move it to `History` but then we need a registry as well
 * do not create an event but make batches history in `History` (we will need an array + a registry)