### PR TITLE
Integrated FocusTracker with the editor.

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -9,6 +9,7 @@ import PluginCollection from '../plugincollection.js';
 import Locale from '../../utils/locale.js';
 import DataController from '../../engine/datacontroller.js';
 import Document from '../../engine/model/document.js';
+import FocusManager from '../../utils/focusmanager.js';
 
 import CKEditorError from '../../utils/ckeditorerror.js';
 import isArray from '../../utils/lib/lodash/isArray.js';
@@ -82,6 +83,13 @@ export default class Editor {
 		 * @member {engine.DataController} core.editor.Editor#data
 		 */
 		this.data = new DataController( this.document );
+
+		/**
+		 * Keeps information about editor focus.
+		 *
+		 * @member {utils.FocusManager} core.editor.Editor#focusManager
+		 */
+		this.focusManager = new FocusManager();
 
 		/**
 		 * Instance of the {@link engine.EditingController editing controller}.

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -9,7 +9,7 @@ import PluginCollection from '../plugincollection.js';
 import Locale from '../../utils/locale.js';
 import DataController from '../../engine/datacontroller.js';
 import Document from '../../engine/model/document.js';
-import FocusManager from '../../utils/focusmanager.js';
+import FocusTracker from '../../utils/focustracker.js';
 
 import CKEditorError from '../../utils/ckeditorerror.js';
 import isArray from '../../utils/lib/lodash/isArray.js';
@@ -87,9 +87,9 @@ export default class Editor {
 		/**
 		 * Keeps information about editor focus.
 		 *
-		 * @member {utils.FocusManager} core.editor.Editor#focusManager
+		 * @member {utils.FocusTracker} core.editor.Editor#focusTracker
 		 */
-		this.focusManager = new FocusManager();
+		this.focusTracker = new FocusTracker();
 
 		/**
 		 * Instance of the {@link engine.EditingController editing controller}.

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -11,7 +11,7 @@ import Editor from '/ckeditor5/core/editor/editor.js';
 import Plugin from '/ckeditor5/core/plugin.js';
 import Config from '/ckeditor5/utils/config.js';
 import PluginCollection from '/ckeditor5/core/plugincollection.js';
-import FocusManager from '/ckeditor5/utils/focusmanager.js';
+import FocusTracker from '/ckeditor5/utils/focustracker.js';
 
 const pluginClasses = {};
 
@@ -29,7 +29,7 @@ describe( 'Editor', () => {
 
 			expect( editor.config ).to.be.an.instanceof( Config );
 			expect( editor.commands ).to.be.an.instanceof( Map );
-			expect( editor.focusManager ).to.instanceOf( FocusManager );
+			expect( editor.focusTracker ).to.instanceOf( FocusTracker );
 
 			expect( editor.plugins ).to.be.an.instanceof( PluginCollection );
 			expect( getPlugins( editor ) ).to.be.empty;

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -11,6 +11,7 @@ import Editor from '/ckeditor5/core/editor/editor.js';
 import Plugin from '/ckeditor5/core/plugin.js';
 import Config from '/ckeditor5/utils/config.js';
 import PluginCollection from '/ckeditor5/core/plugincollection.js';
+import FocusManager from '/ckeditor5/utils/focusmanager.js';
 
 const pluginClasses = {};
 
@@ -28,6 +29,7 @@ describe( 'Editor', () => {
 
 			expect( editor.config ).to.be.an.instanceof( Config );
 			expect( editor.commands ).to.be.an.instanceof( Map );
+			expect( editor.focusManager ).to.instanceOf( FocusManager );
 
 			expect( editor.plugins ).to.be.an.instanceof( PluginCollection );
 			expect( getPlugins( editor ) ).to.be.empty;


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#2854 

Depends on:
- https://github.com/ckeditor/ckeditor5-utils/issues/81
- https://github.com/ckeditor/ckeditor5-editor-classic/issues/31
- https://github.com/ckeditor/ckeditor5-ui-default/issues/81
- https://github.com/ckeditor/ckeditor5-link/issues/36
