### PR TITLE
Changed: ToggleAttributeCommand moved setting selection attributes to enqueueChanges block.

### DIFF
--- a/src/command/toggleattributecommand.js
+++ b/src/command/toggleattributecommand.js
@@ -84,15 +84,15 @@ export default class ToggleAttributeCommand extends Command {
 		const selection = document.selection;
 		const value = ( forceValue === undefined ) ? !this.value : forceValue;
 
-		if ( selection.isCollapsed ) {
-			if ( value ) {
-				selection.setAttribute( this.attributeKey, true );
+		// If selection has non-collapsed ranges, we change attribute on nodes inside those ranges.
+		document.enqueueChanges( () => {
+			if ( selection.isCollapsed ) {
+				if ( value ) {
+					selection.setAttribute( this.attributeKey, true );
+				} else {
+					selection.removeAttribute( this.attributeKey );
+				}
 			} else {
-				selection.removeAttribute( this.attributeKey );
-			}
-		} else {
-			// If selection has non-collapsed ranges, we change attribute on nodes inside those ranges.
-			document.enqueueChanges( () => {
 				const ranges = getSchemaValidRanges( this.attributeKey, selection.getRanges(), document.schema );
 
 				// Keep it as one undo step.
@@ -105,7 +105,7 @@ export default class ToggleAttributeCommand extends Command {
 						batch.removeAttribute( range, this.attributeKey );
 					}
 				}
-			} );
-		}
+			}
+		} );
 	}
 }

--- a/tests/command/toggleattributecommand.js
+++ b/tests/command/toggleattributecommand.js
@@ -166,6 +166,44 @@ describe( 'ToggleAttributeCommand', () => {
 			expect( getData( modelDoc ) )
 				.to.equal( '<p>ab[<$text bold="true">c</$text><image></image><$text bold="true">foobarxy</$text><image></image>]z</p>' );
 		} );
+
+		describe( 'should cause firing model document changesDone event', () => {
+			let spy;
+
+			beforeEach( () => {
+				spy = sinon.spy();
+			} );
+
+			it( 'collapsed selection in non-empty parent', () => {
+				setData( modelDoc, '<p>x[]y</p>' );
+
+				modelDoc.on( 'changesDone', spy );
+
+				command._doExecute();
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+
+			it( 'non-collapsed selection', () => {
+				setData( modelDoc, '<p>[xy]</p>' );
+
+				modelDoc.on( 'changesDone', spy );
+
+				command._doExecute();
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+
+			it( 'in empty parent', () => {
+				setData( modelDoc, '<p>[]</p>' );
+
+				modelDoc.on( 'changesDone', spy );
+
+				command._doExecute();
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+		} );
 	} );
 
 	describe( '_checkEnabled', () => {


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#2850. Changes are the result of fixing https://github.com/ckeditor/ckeditor5-engine/issues/259
