### PR TITLE
t/38: Adapt ClassicTestEditor to Controller–less architecture

### DIFF
--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -32,6 +32,7 @@ describe( 'ClassicTestEditor', () => {
 
 			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
 			expect( editor ).to.have.property( 'element', editorElement );
+			expect( editor ).to.have.property( 'ui' ).to.instanceOf( BoxedEditorUIView );
 		} );
 
 		it( 'creates model and view roots', () => {

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -8,7 +8,7 @@
 import StandardEditor from 'ckeditor5/core/editor/standardeditor.js';
 import ClassicTestEditor from 'tests/core/_utils/classictesteditor.js';
 import HtmlDataProcessor from 'ckeditor5/engine/dataprocessor/htmldataprocessor.js';
-import BoxedEditorUI from 'ckeditor5/ui/editorui/boxed/boxededitorui.js';
+import BoxedEditorUIView from 'ckeditor5/ui/editorui/boxed/boxededitoruiview.js';
 import Feature from 'ckeditor5/core/feature.js';
 
 import { getData } from 'ckeditor5/engine/dev-utils/model.js';
@@ -57,7 +57,7 @@ describe( 'ClassicTestEditor', () => {
 		it( 'creates and initilizes the UI', () => {
 			return ClassicTestEditor.create( editorElement, { foo: 1 } )
 				.then( editor => {
-					expect( editor.ui ).to.be.instanceof( BoxedEditorUI );
+					expect( editor.ui ).to.be.instanceof( BoxedEditorUIView );
 				} );
 		} );
 

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -4,10 +4,7 @@
  */
 
 import StandardEditor from 'ckeditor5/core/editor/standardeditor.js';
-
 import HtmlDataProcessor from 'ckeditor5/engine/dataprocessor/htmldataprocessor.js';
-
-import BoxedEditorUI from 'ckeditor5/ui/editorui/boxed/boxededitorui.js';
 import BoxedEditorUIView from 'ckeditor5/ui/editorui/boxed/boxededitoruiview.js';
 
 /**
@@ -24,13 +21,8 @@ export default class ClassicTestEditor extends StandardEditor {
 		super( element, config );
 
 		this.document.createRoot();
-
 		this.editing.createRoot( 'div' );
-
 		this.data.processor = new HtmlDataProcessor();
-
-		this.ui = new BoxedEditorUI( this );
-		this.ui.view = new BoxedEditorUIView( this.locale );
 	}
 
 	/**
@@ -50,7 +42,9 @@ export default class ClassicTestEditor extends StandardEditor {
 
 			resolve(
 				editor.initPlugins()
-					.then( () => editor.ui.init() )
+					.then( () => {
+						return ( editor.ui = new BoxedEditorUIView( editor, editor.locale ) ).init();
+					} )
 					.then( () => editor.loadDataFromEditorElement() )
 					.then( () => editor )
 			);

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -23,6 +23,8 @@ export default class ClassicTestEditor extends StandardEditor {
 		this.document.createRoot();
 		this.editing.createRoot( 'div' );
 		this.data.processor = new HtmlDataProcessor();
+
+		this.ui = new BoxedEditorUIView( this, this.locale );
 	}
 
 	/**
@@ -42,9 +44,7 @@ export default class ClassicTestEditor extends StandardEditor {
 
 			resolve(
 				editor.initPlugins()
-					.then( () => {
-						return ( editor.ui = new BoxedEditorUIView( editor, editor.locale ) ).init();
-					} )
+					.then( () => editor.ui.init() )
 					.then( () => editor.loadDataFromEditorElement() )
 					.then( () => editor )
 			);


### PR DESCRIPTION
Closes ckeditor/ckeditor5#2866.

Requires https://github.com/ckeditor/ckeditor5-ui-default/pull/104.