### PR TITLE
Fix getSchemaValidRanges schema query

### DIFF
--- a/src/command/helpers/getschemavalidranges.js
+++ b/src/command/helpers/getschemavalidranges.js
@@ -9,6 +9,7 @@
 
 import TreeWalker from '../../../engine/model/treewalker.js';
 import Range from '../../../engine/model/range.js';
+import Position from '../../../engine/model/position.js';
 
 /**
  * Walks through given array of ranges and removes parts of them that are not allowed by passed schema to have the
@@ -32,8 +33,9 @@ export default function getSchemaValidRanges( attribute, ranges, schema ) {
 
 		while ( !step.done ) {
 			const name = step.value.item.name || '$text';
+			const itemPosition = Position.createBefore( step.value.item );
 
-			if ( !schema.check( { name: name, inside: last, attributes: attribute } ) ) {
+			if ( !schema.check( { name: name, inside: itemPosition, attributes: attribute } ) ) {
 				if ( !from.isEqual( last ) ) {
 					validRanges.push( new Range( from, last ) );
 				}

--- a/tests/command/helpers/getschemavalidranges.js
+++ b/tests/command/helpers/getschemavalidranges.js
@@ -42,7 +42,7 @@ describe( 'getSchemaValidRanges', () => {
 		expect( getSchemaValidRanges( attribute, ranges, schema ) ).to.deep.equal( ranges );
 	} );
 
-	it( 'should return two ranges when attribute is not allowed in one item', () => {
+	it( 'should return two ranges when attribute is not allowed on one item', () => {
 		schema.allow( { name: 'img', attributes: 'bold', inside: 'p' } );
 		schema.allow( { name: '$text', inside: 'img' } );
 

--- a/tests/command/toggleattributecommand.js
+++ b/tests/command/toggleattributecommand.js
@@ -158,14 +158,14 @@ describe( 'ToggleAttributeCommand', () => {
 
 		it( 'should not apply attribute change where it would invalid schema', () => {
 			modelDoc.schema.registerItem( 'image', '$block' );
-			setData( modelDoc, '<p>ab[c<image></image><$text bold="true">foobar</$text>xy<image></image>]z</p>' );
+			setData( modelDoc, '<p>ab[c<img></img><$text bold="true">foobar</$text>xy<img></img>]z</p>' );
 
 			expect( command.isEnabled ).to.be.true;
 
 			command._doExecute();
 
 			expect( getData( modelDoc ) )
-				.to.equal( '<p>ab[<$text bold="true">c</$text><image></image><$text bold="true">foobarxy</$text><image></image>]z</p>' );
+				.to.equal( '<p>ab[<$text bold="true">c</$text><img></img><$text bold="true">foobarxy</$text><img></img>]z</p>' );
 		} );
 
 		it( 'should use provided batch for storing undo steps', () => {


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#2875. Requires https://github.com/ckeditor/ckeditor5-engine/pull/733.

I also fixed one more test which fails after https://github.com/ckeditor/ckeditor5-engine/pull/733.