### PR TITLE
T/49: Implement options extraPlugins and removePlugins

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -120,7 +120,10 @@ export default class Editor {
 			.then( () => this.fire( 'pluginsReady' ) );
 
 		function loadPlugins() {
-			return that.plugins.load( config.get( 'plugins' ) || [] );
+			const plugins = config.get( 'plugins' ) || [];
+			const removePlugins = config.get( 'removePlugins' ) || [];
+
+			return that.plugins.load( plugins, removePlugins );
 		}
 
 		function initPlugins( loadedPlugins, method ) {

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -437,9 +437,6 @@ describe( 'Editor', () => {
 			};
 
 			const editor = new CustomEditor( {
-				plugins: [
-					'A'
-				],
 				removePlugins: [ 'D' ]
 			} );
 

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -399,6 +399,56 @@ describe( 'Editor', () => {
 					expect( editor.plugins.get( PluginD ) ).to.be.an.instanceof( Plugin );
 				} );
 		} );
+
+		it( 'should not load plugins specified in the config as "removePlugins"', () => {
+			const editor = new Editor( {
+				plugins: [ PluginA, PluginD ],
+				removePlugins: [ PluginD ]
+			} );
+
+			return editor.initPlugins()
+				.then( () => {
+					expect( getPlugins( editor ).length ).to.equal( 1 );
+					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+				} );
+		} );
+
+		it( 'should not load plugins built in the Editor when "removePlugins" option is specified', () => {
+			Editor.build = {
+				plugins: [ PluginA, PluginD ]
+			};
+
+			const editor = new Editor( {
+				removePlugins: [ 'D' ]
+			} );
+
+			return editor.initPlugins()
+				.then( () => {
+					expect( getPlugins( editor ).length ).to.equal( 1 );
+					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+				} );
+		} );
+
+		it( 'should not load plugins build into Editor\'s subclass when "removePlugins" option is specified', () => {
+			class CustomEditor extends Editor {}
+
+			CustomEditor.build = {
+				plugins: [ PluginA, PluginD ]
+			};
+
+			const editor = new CustomEditor( {
+				plugins: [
+					'A'
+				],
+				removePlugins: [ 'D' ]
+			} );
+
+			return editor.initPlugins()
+				.then( () => {
+					expect( getPlugins( editor ).length ).to.equal( 1 );
+					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+				} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Ability to remove plugins built in the Editor class during plugins initialization. Closes ckeditor/ckeditor5#2873.
