### PR TITLE
T/78: Make Plugin an interface

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -128,6 +128,10 @@ export default class Editor {
 
 		function initPlugins( loadedPlugins, method ) {
 			return loadedPlugins.reduce( ( promise, plugin ) => {
+				if ( !plugin[ method ] ) {
+					return promise;
+				}
+
 				return promise.then( plugin[ method ].bind( plugin ) );
 			}, Promise.resolve() );
 		}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,6 +9,7 @@
 
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 /**
  * The base class for CKEditor plugin classes.
@@ -28,6 +29,7 @@ export default class Plugin {
 	 * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
 	 * plugins, but which doesn't {@link module:core/plugin~Plugin.requires explicitly require} them).
 	 *
+	 * @deprecated
 	 * @param {module:core/editor/editor~Editor} editor
 	 */
 	constructor( editor ) {
@@ -38,6 +40,8 @@ export default class Plugin {
 		 * @member {module:core/editor/editor~Editor} module:core/plugin~Plugin#editor
 		 */
 		this.editor = editor;
+
+		log.warn( 'plugin-instance: This module is deprecated and will be removed.' );
 	}
 
 	/**

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -7,7 +7,6 @@
  * @module core/plugincollection
  */
 
-import Plugin from './plugin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import log from '@ckeditor/ckeditor5-utils/src/log';
 
@@ -58,7 +57,7 @@ export default class PluginCollection {
 	/**
 	 * Collection iterator. Returns `[ PluginConstructor, pluginInstance ]` pairs.
 	 */
-	* [ Symbol.iterator ]() {
+	*[ Symbol.iterator ]() {
 		for ( const entry of this._plugins ) {
 			if ( typeof entry[ 0 ] == 'function' ) {
 				yield entry;
@@ -150,8 +149,6 @@ export default class PluginCollection {
 			return new Promise( resolve => {
 				loading.add( PluginConstructor );
 
-				assertIsPlugin( PluginConstructor );
-
 				if ( PluginConstructor.requires ) {
 					PluginConstructor.requires.forEach( RequiredPluginConstructorOrName => {
 						const RequiredPluginConstructor = getPluginConstructor( RequiredPluginConstructorOrName );
@@ -191,21 +188,6 @@ export default class PluginCollection {
 			return that._availablePlugins.get( PluginConstructorOrName );
 		}
 
-		function assertIsPlugin( PluginConstructor ) {
-			if ( !( PluginConstructor.prototype instanceof Plugin ) ) {
-				/**
-				 * The loaded plugin module is not an instance of {@link module:core/plugin~Plugin}.
-				 *
-				 * @error plugincollection-instance
-				 * @param {*} plugin The constructor which is meant to be loaded as a plugin.
-				 */
-				throw new CKEditorError(
-					'plugincollection-instance: The loaded plugin module is not an instance of Plugin.',
-					{ plugin: PluginConstructor }
-				);
-			}
-		}
-
 		function getMissingPluginNames( plugins ) {
 			const missingPlugins = [];
 
@@ -240,3 +222,97 @@ export default class PluginCollection {
 		}
 	}
 }
+
+/**
+ * The base interface for CKEditor plugins.
+ *
+ * @interface module:core/plugin~Plugin
+ */
+
+/**
+ * An array of plugins required by this plugin.
+ *
+ * To keep a plugin class definition tight it's recommended to define this property as a static getter:
+ *
+ *		import Image from './image.js';
+ *
+ *		export default class ImageCaption {
+ *			static get requires() {
+ *				return [ Image ];
+ *			}
+ *      }
+ *
+ * @static
+ * @readonly
+ * @member {Array.<Function>|undefined} module:core/plugin~Plugin.requires
+ */
+
+/**
+ * Optional name of the plugin. If set, the plugin will be available in
+ * {@link module:core/plugincollection~PluginCollection#get} by its
+ * name and its constructor. If not, then only by its constructor.
+ *
+ * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
+ * should be named `image/image`. If plugin is kept deeper in the directory structure, it's recommended to only use the module file name,
+ * not the whole path. So, e.g. a plugin defined in `ckeditor5-ui/src/notification/notification.js` file may be named `ui/notification`.
+ *
+ * To keep a plugin class definition tight it's recommended to define this property as a static getter:
+ *
+ *		export default class ImageCaption {
+ *			static get pluginName() {
+ *				return 'image/imagecaption';
+ *			}
+ *		}
+ *
+ * @static
+ * @readonly
+ * @member {String|undefined} module:core/plugin~Plugin.pluginName
+ */
+
+/**
+ * The editor instance.
+ *
+ * @readonly
+ * @member {module:core/editor/editor~Editor} module:core/plugin~Plugin#editor
+ */
+
+/**
+ * Creates a plugin instance. This is the first step of a plugin initialization.
+ * See also {@link #init} and {@link #afterInit}.
+ *
+ * A plugin is always instantiated after its {@link module:core/plugin~Plugin.requires dependencies} and the
+ * {@link #init} and {@link #afterInit} methods are called in the same order.
+ *
+ * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
+ * The constructor can be understood as "before init" and used in special cases, just like
+ * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
+ * plugins, but which doesn't {@link module:core/plugin~Plugin.requires explicitly require} them).
+ *
+ * @method constructor
+ * @param {module:core/editor/editor~Editor} editor
+ */
+
+/**
+ * The second stage (after plugin {@link #constructor}) of plugin initialization.
+ * Unlike the plugin constructor this method can perform asynchronous.
+ *
+ * A plugin's `init()` method is called after its {@link module:core/plugin~Plugin.requires dependencies} are initialized,
+ * so in the same order as constructors of these plugins.
+ *
+ * @method init
+ * @returns {null|Promise}
+ */
+
+/**
+ * The third (and last) stage of plugin initialization. See also {@link #constructor} and {@link #init}.
+ *
+ * @method afterInit
+ * @returns {null|Promise}
+ */
+
+/**
+ * Destroys the plugin.
+ *
+ * @method destroy
+ * @returns {null|Promise}
+ */

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -20,14 +20,14 @@ export default class PluginCollection {
 	 *
 	 * @param {module:core/editor/editor~Editor} editor
 	 * @param {Array.<Function>} [availablePlugins] Plugins (constructors) which the collection will be able to use
-	 * when {@link module:core/plugin~PluginCollection#load} is used with plugin names (strings, instead of constructors).
+	 * when {@link module:core/plugincollection~PluginCollection#load} is used with plugin names (strings, instead of constructors).
 	 * Usually, the editor will pass its built-in plugins to the collection so they can later be
 	 * used in `config.plugins` or `config.removePlugins` by names.
 	 */
 	constructor( editor, availablePlugins = [] ) {
 		/**
 		 * @protected
-		 * @member {module:core/editor/editor~Editor} module:core/plugin~PluginCollection#_editor
+		 * @member {module:core/editor/editor~Editor} module:core/plugincollection~PluginCollection#_editor
 		 */
 		this._editor = editor;
 
@@ -35,13 +35,13 @@ export default class PluginCollection {
 		 * Map of plugin constructors which can be retrieved by their names.
 		 *
 		 * @protected
-		 * @member {Map.<String|Function,Function>} module:core/plugin~PluginCollection#_availablePlugins
+		 * @member {Map.<String|Function,Function>} module:core/plugincollection~PluginCollection#_availablePlugins
 		 */
 		this._availablePlugins = new Map();
 
 		/**
 		 * @protected
-		 * @member {Map} module:core/plugin~PluginCollection#_plugins
+		 * @member {Map} module:core/plugincollection~PluginCollection#_plugins
 		 */
 		this._plugins = new Map();
 
@@ -68,8 +68,8 @@ export default class PluginCollection {
 	/**
 	 * Gets the plugin instance by its constructor or name.
 	 *
-	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~Plugin.pluginName name}.
-	 * @returns {module:core/plugin~Plugin}
+	 * @param {Function|String} key The plugin constructor or {@link module:core/plugincollection~Plugin.pluginName name}.
+	 * @returns {module:core/plugincollection~Plugin}
 	 */
 	get( key ) {
 		return this._plugins.get( key );
@@ -78,14 +78,14 @@ export default class PluginCollection {
 	/**
 	 * Loads a set of plugins and adds them to the collection.
 	 *
-	 * @param {Array.<Function|String>} plugins An array of {@link module:core/plugin~Plugin plugin constructors}
-	 * or {@link module:core/plugin~Plugin.pluginName plugin names}. The second option (names) work only if
+	 * @param {Array.<Function|String>} plugins An array of {@link module:core/plugincollection~Plugin plugin constructors}
+	 * or {@link module:core/plugincollection~Plugin.pluginName plugin names}. The second option (names) work only if
 	 * `availablePlugins` were passed to the {@link #constructor}.
 	 * @param {Array.<String|Function>} [removePlugins] Names of plugins or plugin constructors
 	 * which should not be loaded (despite being specified in the `plugins` array).
 	 * @returns {Promise} A promise which gets resolved once all plugins are loaded and available into the
 	 * collection.
-	 * @returns {Promise.<Array.<module:core/plugin~Plugin>>} returns.loadedPlugins The array of loaded plugins.
+	 * @returns {Promise.<Array.<module:core/plugincollection~Plugin>>} returns.loadedPlugins The array of loaded plugins.
 	 */
 	load( plugins, removePlugins = [] ) {
 		const that = this;
@@ -212,7 +212,7 @@ export default class PluginCollection {
 	 *
 	 * @protected
 	 * @param {Function} PluginConstructor The plugin constructor.
-	 * @param {module:core/plugin~Plugin} plugin The instance of the plugin.
+	 * @param {module:core/plugincollection~Plugin} plugin The instance of the plugin.
 	 */
 	_add( PluginConstructor, plugin ) {
 		this._plugins.set( PluginConstructor, plugin );
@@ -226,7 +226,7 @@ export default class PluginCollection {
 /**
  * The base interface for CKEditor plugins.
  *
- * @interface module:core/plugin~Plugin
+ * @interface Plugin
  */
 
 /**
@@ -244,12 +244,12 @@ export default class PluginCollection {
  *
  * @static
  * @readonly
- * @member {Array.<Function>|undefined} module:core/plugin~Plugin.requires
+ * @member {Array.<Function>|undefined} module:core/plugincollection~Plugin.requires
  */
 
 /**
  * Optional name of the plugin. If set, the plugin will be available in
- * {@link module:core/plugincollection~PluginCollection#get} by its
+ * {@link module:core/plugincollectioncollection~PluginCollection#get} by its
  * name and its constructor. If not, then only by its constructor.
  *
  * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
@@ -266,27 +266,27 @@ export default class PluginCollection {
  *
  * @static
  * @readonly
- * @member {String|undefined} module:core/plugin~Plugin.pluginName
+ * @member {String|undefined} module:core/plugincollection~Plugin.pluginName
  */
 
 /**
  * The editor instance.
  *
  * @readonly
- * @member {module:core/editor/editor~Editor} module:core/plugin~Plugin#editor
+ * @member {module:core/editor/editor~Editor} module:core/plugincollection~Plugin#editor
  */
 
 /**
  * Creates a plugin instance. This is the first step of a plugin initialization.
  * See also {@link #init} and {@link #afterInit}.
  *
- * A plugin is always instantiated after its {@link module:core/plugin~Plugin.requires dependencies} and the
+ * A plugin is always instantiated after its {@link module:core/plugincollection~Plugin.requires dependencies} and the
  * {@link #init} and {@link #afterInit} methods are called in the same order.
  *
  * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
  * The constructor can be understood as "before init" and used in special cases, just like
  * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
- * plugins, but which doesn't {@link module:core/plugin~Plugin.requires explicitly require} them).
+ * plugins, but which doesn't {@link module:core/plugincollection~Plugin.requires explicitly require} them).
  *
  * @method constructor
  * @param {module:core/editor/editor~Editor} editor
@@ -296,7 +296,7 @@ export default class PluginCollection {
  * The second stage (after plugin {@link #constructor}) of plugin initialization.
  * Unlike the plugin constructor this method can perform asynchronous.
  *
- * A plugin's `init()` method is called after its {@link module:core/plugin~Plugin.requires dependencies} are initialized,
+ * A plugin's `init()` method is called after its {@link module:core/plugincollection~Plugin.requires dependencies} are initialized,
  * so in the same order as constructors of these plugins.
  *
  * @method init

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -57,7 +57,7 @@ export default class PluginCollection {
 	/**
 	 * Collection iterator. Returns `[ PluginConstructor, pluginInstance ]` pairs.
 	 */
-	*[ Symbol.iterator ]() {
+	* [ Symbol.iterator ]() {
 		for ( const entry of this._plugins ) {
 			if ( typeof entry[ 0 ] == 'function' ) {
 				yield entry;

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -8,7 +8,6 @@
 import StandardEditor from '../../src/editor/standardeditor';
 import ClassicTestEditor from '../../tests/_utils/classictesteditor';
 
-import Plugin from '../../src/plugin';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 import ClassicTestEditorUI from '../../tests/_utils/classictesteditorui';
@@ -79,7 +78,11 @@ describe( 'ClassicTestEditor', () => {
 		it( 'loads data from the editor element', () => {
 			editorElement.innerHTML = 'foo';
 
-			class PluginTextInRoot extends Plugin {
+			class PluginTextInRoot {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				}
@@ -98,7 +101,11 @@ describe( 'ClassicTestEditor', () => {
 				fired.push( evt.name );
 			}
 
-			class EventWatcher extends Plugin {
+			class EventWatcher {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.on( 'uiReady', spy );

--- a/tests/_utils-tests/modeltesteditor.js
+++ b/tests/_utils-tests/modeltesteditor.js
@@ -6,7 +6,6 @@
 import Editor from '../../src/editor/editor';
 import ModelTestEditor from '../../tests/_utils/modeltesteditor';
 
-import Plugin from '../../src/plugin';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -50,7 +49,11 @@ describe( 'ModelTestEditor', () => {
 				fired.push( evt.name );
 			}
 
-			class EventWatcher extends Plugin {
+			class EventWatcher {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.on( 'dataReady', spy );

--- a/tests/_utils-tests/virtualtesteditor.js
+++ b/tests/_utils-tests/virtualtesteditor.js
@@ -6,7 +6,6 @@
 import StandardEditor from '../../src/editor/standardeditor';
 import VirtualTestEditor from '../../tests/_utils/virtualtesteditor';
 
-import Plugin from '../../src/plugin';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 import testUtils from '../../tests/_utils/utils';
@@ -49,7 +48,11 @@ describe( 'VirtualTestEditor', () => {
 				fired.push( evt.name );
 			}
 
-			class EventWatcher extends Plugin {
+			class EventWatcher {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.on( 'dataReady', spy );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -6,13 +6,12 @@
 /* globals setTimeout */
 
 import Editor from '../../src/editor/editor';
-import Plugin from '../../src/plugin';
 import Config from '@ckeditor/ckeditor5-utils/src/config';
 import PluginCollection from '../../src/plugincollection';
 
-class PluginA extends Plugin {
+class PluginA {
 	constructor( editor ) {
-		super( editor );
+		this.editor = editor;
 		this.init = sinon.spy().named( 'A' );
 		this.afterInit = sinon.spy().named( 'A-after' );
 	}
@@ -22,9 +21,9 @@ class PluginA extends Plugin {
 	}
 }
 
-class PluginB extends Plugin {
+class PluginB {
 	constructor( editor ) {
-		super( editor );
+		this.editor = editor;
 		this.init = sinon.spy().named( 'B' );
 		this.afterInit = sinon.spy().named( 'B-after' );
 	}
@@ -34,9 +33,9 @@ class PluginB extends Plugin {
 	}
 }
 
-class PluginC extends Plugin {
+class PluginC {
 	constructor( editor ) {
-		super( editor );
+		this.editor = editor;
 		this.init = sinon.spy().named( 'C' );
 		this.afterInit = sinon.spy().named( 'C-after' );
 	}
@@ -50,9 +49,9 @@ class PluginC extends Plugin {
 	}
 }
 
-class PluginD extends Plugin {
+class PluginD {
 	constructor( editor ) {
-		super( editor );
+		this.editor = editor;
 		this.init = sinon.spy().named( 'D' );
 		this.afterInit = sinon.spy().named( 'D-after' );
 	}
@@ -127,13 +126,11 @@ describe( 'Editor', () => {
 		} );
 
 		it( 'loads plugins', () => {
-			return Editor.create( {
-				plugins: [ PluginA ]
-			} )
+			return Editor.create( { plugins: [ PluginA ] } )
 				.then( editor => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
 
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -144,7 +141,11 @@ describe( 'Editor', () => {
 				fired.push( evt.name );
 			}
 
-			class EventWatcher extends Plugin {
+			class EventWatcher {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.on( 'dataReady', spy );
@@ -170,8 +171,8 @@ describe( 'Editor', () => {
 			return editor.initPlugins().then( () => {
 				expect( getPlugins( editor ).length ).to.equal( 2 );
 
-				expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
-				expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+				expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+				expect( editor.plugins.get( PluginB ) ).to.not.be.undefined;
 			} );
 		} );
 
@@ -183,28 +184,29 @@ describe( 'Editor', () => {
 			const pluginsReadySpy = sinon.spy().named( 'pluginsReady' );
 			editor.on( 'pluginsReady', pluginsReadySpy );
 
-			return editor.initPlugins().then( () => {
-				sinon.assert.callOrder(
-					editor.plugins.get( PluginA ).init,
-					editor.plugins.get( PluginB ).init,
-					editor.plugins.get( PluginC ).init,
-					editor.plugins.get( PluginD ).init,
-					editor.plugins.get( PluginA ).afterInit,
-					editor.plugins.get( PluginB ).afterInit,
-					editor.plugins.get( PluginC ).afterInit,
-					editor.plugins.get( PluginD ).afterInit,
-					pluginsReadySpy
-				);
-			} );
+			return editor.initPlugins()
+				.then( () => {
+					sinon.assert.callOrder(
+						editor.plugins.get( PluginA ).init,
+						editor.plugins.get( PluginB ).init,
+						editor.plugins.get( PluginC ).init,
+						editor.plugins.get( PluginD ).init,
+						editor.plugins.get( PluginA ).afterInit,
+						editor.plugins.get( PluginB ).afterInit,
+						editor.plugins.get( PluginC ).afterInit,
+						editor.plugins.get( PluginD ).afterInit,
+						pluginsReadySpy
+					);
+				} );
 		} );
 
 		it( 'should initialize plugins in the right order, waiting for asynchronous init()', () => {
 			const asyncSpy = sinon.spy().named( 'async-call-spy' );
 
 			// Synchronous plugin that depends on an asynchronous one.
-			class PluginSync extends Plugin {
+			class PluginSync {
 				constructor( editor ) {
-					super( editor );
+					this.editor = editor;
 					this.init = sinon.spy().named( 'sync' );
 				}
 
@@ -213,10 +215,9 @@ describe( 'Editor', () => {
 				}
 			}
 
-			class PluginAsync extends Plugin {
+			class PluginAsync {
 				constructor( editor ) {
-					super( editor );
-
+					this.editor = editor;
 					this.init = sinon.spy( () => {
 						return new Promise( resolve => {
 							setTimeout( () => {
@@ -248,9 +249,9 @@ describe( 'Editor', () => {
 			const asyncSpy = sinon.spy().named( 'async-call-spy' );
 
 			// Synchronous plugin that depends on an asynchronous one.
-			class PluginSync extends Plugin {
+			class PluginSync {
 				constructor( editor ) {
-					super( editor );
+					this.editor = editor;
 					this.afterInit = sinon.spy().named( 'sync' );
 				}
 
@@ -259,10 +260,9 @@ describe( 'Editor', () => {
 				}
 			}
 
-			class PluginAsync extends Plugin {
+			class PluginAsync {
 				constructor( editor ) {
-					super( editor );
-
+					this.editor = editor;
 					this.afterInit = sinon.spy( () => {
 						return new Promise( resolve => {
 							setTimeout( () => {
@@ -302,9 +302,9 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 3 );
 
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginB ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginC ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -323,12 +323,12 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
 
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
 				} );
 		} );
 
 		it( 'should load plugins built in the Editor using their names', () => {
-			class PrivatePlugin extends Plugin {}
+			class PrivatePlugin {}
 
 			Editor.build = {
 				plugins: [ PluginA, PluginB, PluginC, PluginD ]
@@ -347,9 +347,9 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 4 );
 
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginB ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginC ) ).to.not.be.undefined;
 					expect( editor.plugins.get( PrivatePlugin ) ).to.be.an.instanceof( PrivatePlugin );
 				} );
 		} );
@@ -371,9 +371,9 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 3 );
 
-					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginD ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginB ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginC ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginD ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -394,9 +394,9 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 3 );
 
-					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
-					expect( editor.plugins.get( PluginD ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginB ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginC ) ).to.not.be.undefined;
+					expect( editor.plugins.get( PluginD ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -409,7 +409,7 @@ describe( 'Editor', () => {
 			return editor.initPlugins()
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -425,7 +425,7 @@ describe( 'Editor', () => {
 			return editor.initPlugins()
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
 				} );
 		} );
 
@@ -443,7 +443,7 @@ describe( 'Editor', () => {
 			return editor.initPlugins()
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
 				} );
 		} );
 	} );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -65,6 +65,28 @@ class PluginD {
 	}
 }
 
+class PluginE {
+	constructor( editor ) {
+		this.editor = editor;
+		this.init = sinon.spy().named( 'E' );
+	}
+
+	static get pluginName() {
+		return 'E';
+	}
+}
+
+class PluginF {
+	constructor( editor ) {
+		this.editor = editor;
+		this.afterInit = sinon.spy().named( 'F-after' );
+	}
+
+	static get pluginName() {
+		return 'F';
+	}
+}
+
 describe( 'Editor', () => {
 	afterEach( () => {
 		delete Editor.build;
@@ -444,6 +466,44 @@ describe( 'Editor', () => {
 				.then( () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
 					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+				} );
+		} );
+
+		it( 'should not call "afterInit" method if plugin does not have this method', () => {
+			const editor = new Editor( {
+				plugins: [ PluginA, PluginE ]
+			} );
+
+			const pluginsReadySpy = sinon.spy().named( 'pluginsReady' );
+			editor.on( 'pluginsReady', pluginsReadySpy );
+
+			return editor.initPlugins()
+				.then( () => {
+					sinon.assert.callOrder(
+						editor.plugins.get( PluginA ).init,
+						editor.plugins.get( PluginE ).init,
+						editor.plugins.get( PluginA ).afterInit,
+						pluginsReadySpy
+					);
+				} );
+		} );
+
+		it( 'should not call "init" method if plugin does not have this method', () => {
+			const editor = new Editor( {
+				plugins: [ PluginA, PluginF ]
+			} );
+
+			const pluginsReadySpy = sinon.spy().named( 'pluginsReady' );
+			editor.on( 'pluginsReady', pluginsReadySpy );
+
+			return editor.initPlugins()
+				.then( () => {
+					sinon.assert.callOrder(
+						editor.plugins.get( PluginA ).init,
+						editor.plugins.get( PluginA ).afterInit,
+						editor.plugins.get( PluginF ).afterInit,
+						pluginsReadySpy
+					);
 				} );
 		} );
 	} );

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -12,7 +12,6 @@ import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model
 
 import EditingController from '@ckeditor/ckeditor5-engine/src/controller/editingcontroller';
 import EditingKeystrokeHandler from '../../src/editingkeystrokehandler';
-import Plugin from '../../src/plugin';
 
 describe( 'StandardEditor', () => {
 	let editorElement;
@@ -91,7 +90,11 @@ describe( 'StandardEditor', () => {
 
 	describe( 'create()', () => {
 		it( 'initializes editor with plugins and config', () => {
-			class PluginFoo extends Plugin {}
+			class PluginFoo {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+			}
 
 			return StandardEditor.create( editorElement, { foo: 1, plugins: [ PluginFoo ] } )
 				.then( editor => {
@@ -111,7 +114,11 @@ describe( 'StandardEditor', () => {
 				fired.push( evt.name );
 			}
 
-			class EventWatcher extends Plugin {
+			class EventWatcher {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.on( 'dataReady', spy );

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -6,14 +6,13 @@
 import testUtils from '../tests/_utils/utils';
 import Editor from '../src/editor/editor';
 import PluginCollection from '../src/plugincollection';
-import Plugin from '../src/plugin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import log from '@ckeditor/ckeditor5-utils/src/log';
 
 let editor, availablePlugins;
 let PluginA, PluginB, PluginC, PluginD, PluginE, PluginF, PluginG, PluginH, PluginI, PluginJ, PluginK, PluginX;
 class TestError extends Error {}
-class ChildPlugin extends Plugin {}
+class ChildPlugin {}
 class GrandPlugin extends ChildPlugin {}
 
 testUtils.createSinonSandbox();
@@ -30,10 +29,8 @@ before( () => {
 	PluginI = createPlugin( 'I' );
 	PluginJ = createPlugin( 'J' );
 	PluginK = createPlugin( 'K' );
-	PluginX = class extends Plugin {
-		constructor( editor ) {
-			super( editor );
-
+	PluginX = class {
+		constructor() {
 			throw new TestError( 'Some error inside a plugin' );
 		}
 	};
@@ -216,29 +213,6 @@ describe( 'PluginCollection', () => {
 				} );
 		} );
 
-		it( 'should reject when loading a module which is not a plugin', () => {
-			class Y {}
-
-			availablePlugins.push( Y );
-
-			const logSpy = testUtils.sinon.stub( log, 'error' );
-
-			const plugins = new PluginCollection( editor, availablePlugins );
-
-			return plugins.load( [ Y ] )
-				// Throw here, so if by any chance plugins.load() was resolved correctly catch() will be stil executed.
-				.then( () => {
-					throw new Error( 'Test error: this promise should not be resolved successfully' );
-				} )
-				.catch( err => {
-					expect( err ).to.be.an.instanceof( CKEditorError );
-					expect( err.message ).to.match( /^plugincollection-instance/ );
-
-					sinon.assert.calledOnce( logSpy );
-					expect( logSpy.args[ 0 ][ 0 ] ).to.match( /^plugincollection-load:/ );
-				} );
-		} );
-
 		it( 'should reject when loading non-existent plugin', () => {
 			const logSpy = testUtils.sinon.stub( log, 'error' );
 
@@ -307,7 +281,7 @@ describe( 'PluginCollection', () => {
 		} );
 
 		it( 'should load chosen plugins (plugins are names, removePlugins contains an anonymous plugin)', () => {
-			class AnonymousPlugin extends Plugin {}
+			class AnonymousPlugin {}
 
 			const plugins = new PluginCollection( editor, [ AnonymousPlugin ].concat( availablePlugins ) );
 
@@ -340,7 +314,7 @@ describe( 'PluginCollection', () => {
 
 	describe( 'get()', () => {
 		it( 'retrieves plugin by its constructor', () => {
-			class SomePlugin extends Plugin {}
+			class SomePlugin {}
 
 			availablePlugins.push( SomePlugin );
 
@@ -353,7 +327,7 @@ describe( 'PluginCollection', () => {
 		} );
 
 		it( 'retrieves plugin by its name and constructor', () => {
-			class SomePlugin extends Plugin {}
+			class SomePlugin {}
 			SomePlugin.pluginName = 'foo/bar';
 
 			availablePlugins.push( SomePlugin );
@@ -376,8 +350,8 @@ describe( 'PluginCollection', () => {
 		} );
 
 		it( 'returns only plugins by constructors', () => {
-			class SomePlugin1 extends Plugin {}
-			class SomePlugin2 extends Plugin {}
+			class SomePlugin1 {}
+			class SomePlugin2 {}
 			SomePlugin2.pluginName = 'foo/bar';
 
 			availablePlugins.push( SomePlugin1 );
@@ -397,9 +371,9 @@ describe( 'PluginCollection', () => {
 } );
 
 function createPlugin( name ) {
-	const P = class extends Plugin {
+	const P = class {
 		constructor( editor ) {
-			super( editor );
+			this.editor = editor;
 			this.pluginName = name;
 		}
 	};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Editor's plugins do not have to extend the base Plugin class. Plugins can be simple function now. Closes ckeditor/ckeditor5#2913.

---

### Additional information

In fact, this PR does not resolve ckeditor/ckeditor5#2913 in 100% but allows converting existing plugins to simple functions.

I would mark this PR as `WIP`.