### PR TITLE
T/78: Make Plugin an interface (PluginInterface)

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -128,6 +128,10 @@ export default class Editor {
 
 		function initPlugins( loadedPlugins, method ) {
 			return loadedPlugins.reduce( ( promise, plugin ) => {
+				if ( !plugin[ method ] ) {
+					return promise;
+				}
+
 				return promise.then( plugin[ method ].bind( plugin ) );
 			}, Promise.resolve() );
 		}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,20 +13,14 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
 /**
  * The base class for CKEditor plugin classes.
  *
+ * @implements module:core/plugin~PluginInterface
  * @mixes module:utils/observablemixin~ObservaleMixin
  */
 export default class Plugin {
 	/**
-	 * Creates a new Plugin instance. This is the first step of a plugin initialization.
-	 * See also {@link #init} and {@link #afterInit}.
-	 *
-	 * A plugin is always instantiated after its {@link module:core/plugin~Plugin.requires dependencies} and the
-	 * {@link #init} and {@link #afterInit} methods are called in the same order.
-	 *
-	 * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
-	 * The constructor can be understood as "before init" and used in special cases, just like
-	 * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
-	 * plugins, but which doesn't {@link module:core/plugin~Plugin.requires explicitly require} them).
+	 * Creates a new Plugin instance. This is the
+	 * {@link module:core/plugin~PluginInterface#constructor first step} of a plugin initialization. See also
+	 * {@link module:core/plugin~PluginInterface#init} and {@link module:core/plugin~PluginInterface#afterInit}.
 	 *
 	 * @param {module:core/editor/editor~Editor} editor
 	 */
@@ -41,70 +35,113 @@ export default class Plugin {
 	}
 
 	/**
-	 * An array of plugins required by this plugin.
-	 *
-	 * To keep a plugin class definition tight it's recommended to define this property as a static getter:
-	 *
-	 *		import Image from './image.js';
-	 *
-	 *		export default class ImageCaption extends Plugin {
-     *			static get requires() {
-     *				return [ Image ];
-     *			}
-	 *		}
-	 *
-	 * @static
-	 * @readonly
-	 * @member {Array.<Function>|undefined} module:core/plugin~Plugin.requires
-	 */
-
-	/**
-	 * Optional name of the plugin. If set, the plugin will be available in
-	 * {@link module:core/plugincollection~PluginCollection#get} by its
-	 * name and its constructor. If not, then only by its constructor.
-	 *
-	 * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
-	 * should be named `image/image` (the `ckeditor5-` prefix is stripped during compilation). If plugin is kept
-	 * deeper in the directory structure, it's recommended to only use the module file name, not the whole path.
-	 * So, e.g. a plugin defined in `ckeditor5-ui/src/notification/notification.js` file may be named `ui/notification`.
-	 *
-	 * To keep a plugin class definition tight it's recommended to define this property as a static getter:
-	 *
-	 *		export default class ImageCaption {
-     *			static get pluginName() {
-     *				return 'image/imagecaption';
-     *			}
-	 *		}
-	 *
-	 * @static
-	 * @readonly
-	 * @member {String|undefined} module:core/plugin~Plugin.pluginName
-	 */
-
-	/**
-	 * The second stage (after plugin {@link #constructor}) of plugin initialization.
-	 * Unlike the plugin constructor this method can perform asynchronous.
-	 *
-	 * A plugin's `init()` method is called after its {@link module:core/plugin~Plugin.requires dependencies} are initialized,
-	 * so in the same order as constructors of these plugins.
-	 *
 	 * @returns {null|Promise}
 	 */
 	init() {}
 
 	/**
-	 * The third (and last) stage of plugin initialization. See also {@link #constructor} and {@link #init}.
-	 *
 	 * @returns {null|Promise}
 	 */
 	afterInit() {}
 
 	/**
-	 * Destroys the plugin.
-	 *
 	 * @returns {null|Promise}
 	 */
 	destroy() {}
 }
 
 mix( Plugin, ObservableMixin );
+
+/**
+ * The base interface for CKEditor plugins.
+ *
+ * @interface Plugin
+ */
+
+/**
+ * An array of plugins required by this plugin.
+ *
+ * To keep a plugin class definition tight it's recommended to define this property as a static getter:
+ *
+ *		import Image from './image.js';
+ *
+ *		export default class ImageCaption {
+ *			static get requires() {
+ *				return [ Image ];
+ *			}
+ *      }
+ *
+ * @static
+ * @readonly
+ * @member {Array.<Function>|undefined} module:core/plugin~PluginInterface.requires
+ */
+
+/**
+ * Optional name of the plugin. If set, the plugin will be available in
+ * {@link module:core/plugincollectioncollection~PluginCollection#get} by its
+ * name and its constructor. If not, then only by its constructor.
+ *
+ * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
+ * should be named `image/image`. If plugin is kept deeper in the directory structure, it's recommended to only use the module file name,
+ * not the whole path. So, e.g. a plugin defined in `ckeditor5-ui/src/notification/notification.js` file may be named `ui/notification`.
+ *
+ * To keep a plugin class definition tight it's recommended to define this property as a static getter:
+ *
+ *		export default class ImageCaption {
+ *			static get pluginName() {
+ *				return 'image/imagecaption';
+ *			}
+ *		}
+ *
+ * @static
+ * @readonly
+ * @member {String|undefined} module:core/plugin~PluginInterface.pluginName
+ */
+
+/**
+ * The editor instance.
+ *
+ * @readonly
+ * @member {module:core/editor/editor~Editor} module:core/plugin~PluginInterface#editor
+ */
+
+/**
+ * Creates a plugin instance. This is the first step of a plugin initialization.
+ * See also {@link #init} and {@link #afterInit}.
+ *
+ * A plugin is always instantiated after its {@link module:core/plugin~PluginInterface.requires dependencies} and the
+ * {@link #init} and {@link #afterInit} methods are called in the same order.
+ *
+ * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
+ * The constructor can be understood as "before init" and used in special cases, just like
+ * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
+ * plugins, but which doesn't {@link module:core/plugin~PluginInterface.requires explicitly require} them).
+ *
+ * @method constructor
+ * @param {module:core/editor/editor~Editor} editor
+ */
+
+/**
+ * The second stage (after plugin {@link #constructor}) of plugin initialization.
+ * Unlike the plugin constructor this method can perform asynchronous.
+ *
+ * A plugin's `init()` method is called after its {@link module:core/plugin~PluginInterface.requires dependencies} are initialized,
+ * so in the same order as constructors of these plugins.
+ *
+ * @method init
+ * @returns {null|Promise}
+ */
+
+/**
+ * The third (and last) stage of plugin initialization. See also {@link #constructor} and {@link #init}.
+ *
+ * @method afterInit
+ * @returns {null|Promise}
+ */
+
+/**
+ * Destroys the plugin.
+ *
+ * @method destroy
+ * @returns {null|Promise}
+ */

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -29,6 +29,12 @@ export default class Plugin {
 		 */
 		this.editor = editor;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+	}
 }
 
 mix( Plugin, ObservableMixin );

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,7 +14,7 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * The base class for CKEditor plugin classes.
  *
  * @implements module:core/plugin~PluginInterface
- * @mixes module:utils/observablemixin~ObservaleMixin
+ * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class Plugin {
 	/**
@@ -102,7 +102,7 @@ mix( Plugin, ObservableMixin );
  * The editor instance.
  *
  * @readonly
- * @member {module:core/editor/editor~Editor} module:core/plugin~PluginInterface#editor
+ * @member {module:core/editor/editor~Editor} #editor
  */
 
 /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -18,36 +18,17 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  */
 export default class Plugin {
 	/**
-	 * Creates a new Plugin instance. This is the
-	 * {@link module:core/plugin~PluginInterface#constructor first step} of a plugin initialization. See also
-	 * {@link module:core/plugin~PluginInterface#init} and {@link module:core/plugin~PluginInterface#afterInit}.
-	 *
-	 * @param {module:core/editor/editor~Editor} editor
+	 * @inheritDoc
 	 */
 	constructor( editor ) {
 		/**
 		 * The editor instance.
 		 *
 		 * @readonly
-		 * @member {module:core/editor/editor~Editor} module:core/plugin~Plugin#editor
+		 * @member {module:core/editor/editor~Editor} #editor
 		 */
 		this.editor = editor;
 	}
-
-	/**
-	 * @returns {null|Promise}
-	 */
-	init() {}
-
-	/**
-	 * @returns {null|Promise}
-	 */
-	afterInit() {}
-
-	/**
-	 * @returns {null|Promise}
-	 */
-	destroy() {}
 }
 
 mix( Plugin, ObservableMixin );
@@ -55,7 +36,46 @@ mix( Plugin, ObservableMixin );
 /**
  * The base interface for CKEditor plugins.
  *
+ * In its minimal form it can be a simple function (it will be used as a constructor) which accepts
+ * {@link module:core/editor/editor~Editor the editor} as a parm.
+ * It can also implement a few methods which, when present, will be used to properly initialize and destroy the plugin.
+ *
+ *		// A simple plugin which enables a data processor.
+ *		function MyPlugin( editor ) {
+ *			editor.data.processor = new MyDataProcessor();
+ *		}
+ *
+ * In most cases, however, you'll want to inherit from the {@link module:core/plugin~Plugin} class which implements the
+ * {@link module:utils/observablemixin~ObservableMixin} and is, therefore, more convenient:
+ *
+ *		class MyPlugin extends Plugin {
+ *			init() {
+ *				// `listenTo()` and `editor` are available thanks to `Plugin`.
+ *				// By using `listenTo()` you'll ensure that the listener will be removed when
+ *				// the plugin is destroyed.
+ *				this.listenTo( this.editor, 'dataReady', () => {
+ *					// Do something when data is ready.
+ *				} );
+ *			}
+ *		}
+ *
  * @interface PluginInterface
+ */
+
+/**
+ * Creates a new plugin instance. This is the first step of a plugin initialization.
+ * See also {@link #init} and {@link #afterInit}.
+ *
+ * A plugin is always instantiated after its {@link module:core/plugin~PluginInterface.requires dependencies} and the
+ * {@link #init} and {@link #afterInit} methods are called in the same order.
+ *
+ * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
+ * The constructor can be understood as "before init" and used in special cases, just like
+ * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
+ * plugins, but which doesn't {@link module:core/plugin~PluginInterface.requires explicitly require} them).
+ *
+ * @method #constructor
+ * @param {module:core/editor/editor~Editor} editor
  */
 
 /**
@@ -99,34 +119,13 @@ mix( Plugin, ObservableMixin );
  */
 
 /**
- * The editor instance.
- *
- * @readonly
- * @member {module:core/editor/editor~Editor} #editor
- */
-
-/**
- * Creates a plugin instance. This is the first step of a plugin initialization.
- * See also {@link #init} and {@link #afterInit}.
- *
- * A plugin is always instantiated after its {@link module:core/plugin~PluginInterface.requires dependencies} and the
- * {@link #init} and {@link #afterInit} methods are called in the same order.
- *
- * Usually, you'll want to put your plugin's initialization code in the {@link #init} method.
- * The constructor can be understood as "before init" and used in special cases, just like
- * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
- * plugins, but which doesn't {@link module:core/plugin~PluginInterface.requires explicitly require} them).
- *
- * @method #constructor
- * @param {module:core/editor/editor~Editor} editor
- */
-
-/**
  * The second stage (after plugin {@link #constructor}) of plugin initialization.
- * Unlike the plugin constructor this method can perform asynchronous.
+ * Unlike the plugin constructor this method can be asynchronous.
  *
  * A plugin's `init()` method is called after its {@link module:core/plugin~PluginInterface.requires dependencies} are initialized,
  * so in the same order as constructors of these plugins.
+ *
+ * **Note:** This method is optional. A plugin instance does not need to have to have it defined.
  *
  * @method #init
  * @returns {null|Promise}
@@ -135,12 +134,16 @@ mix( Plugin, ObservableMixin );
 /**
  * The third (and last) stage of plugin initialization. See also {@link #constructor} and {@link #init}.
  *
+ * **Note:** This method is optional. A plugin instance does not need to have to have it defined.
+ *
  * @method #afterInit
  * @returns {null|Promise}
  */
 
 /**
  * Destroys the plugin.
+ *
+ * **Note:** This method is optional. A plugin instance does not need to have to have it defined.
  *
  * @method #destroy
  * @returns {null|Promise}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -55,7 +55,7 @@ mix( Plugin, ObservableMixin );
 /**
  * The base interface for CKEditor plugins.
  *
- * @interface Plugin
+ * @interface PluginInterface
  */
 
 /**
@@ -78,7 +78,7 @@ mix( Plugin, ObservableMixin );
 
 /**
  * Optional name of the plugin. If set, the plugin will be available in
- * {@link module:core/plugincollectioncollection~PluginCollection#get} by its
+ * {@link module:core/plugincollection~PluginCollection#get} by its
  * name and its constructor. If not, then only by its constructor.
  *
  * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
@@ -117,7 +117,7 @@ mix( Plugin, ObservableMixin );
  * {@link #afterInit} servers for the special "after init" scenarios (e.g. code which depends on other
  * plugins, but which doesn't {@link module:core/plugin~PluginInterface.requires explicitly require} them).
  *
- * @method constructor
+ * @method #constructor
  * @param {module:core/editor/editor~Editor} editor
  */
 
@@ -128,20 +128,20 @@ mix( Plugin, ObservableMixin );
  * A plugin's `init()` method is called after its {@link module:core/plugin~PluginInterface.requires dependencies} are initialized,
  * so in the same order as constructors of these plugins.
  *
- * @method init
+ * @method #init
  * @returns {null|Promise}
  */
 
 /**
  * The third (and last) stage of plugin initialization. See also {@link #constructor} and {@link #init}.
  *
- * @method afterInit
+ * @method #afterInit
  * @returns {null|Promise}
  */
 
 /**
  * Destroys the plugin.
  *
- * @method destroy
+ * @method #destroy
  * @returns {null|Promise}
  */

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -7,7 +7,6 @@
  * @module core/plugincollection
  */
 
-import Plugin from './plugin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import log from '@ckeditor/ckeditor5-utils/src/log';
 
@@ -150,8 +149,6 @@ export default class PluginCollection {
 			return new Promise( resolve => {
 				loading.add( PluginConstructor );
 
-				assertIsPlugin( PluginConstructor );
-
 				if ( PluginConstructor.requires ) {
 					PluginConstructor.requires.forEach( RequiredPluginConstructorOrName => {
 						const RequiredPluginConstructor = getPluginConstructor( RequiredPluginConstructorOrName );
@@ -189,21 +186,6 @@ export default class PluginCollection {
 			}
 
 			return that._availablePlugins.get( PluginConstructorOrName );
-		}
-
-		function assertIsPlugin( PluginConstructor ) {
-			if ( !( PluginConstructor.prototype instanceof Plugin ) ) {
-				/**
-				 * The loaded plugin module is not an instance of {@link module:core/plugin~PluginInterface}.
-				 *
-				 * @error plugincollection-instance
-				 * @param {*} plugin The constructor which is meant to be loaded as a plugin.
-				 */
-				throw new CKEditorError(
-					'plugincollection-instance: The loaded plugin module is not an instance of Plugin.',
-					{ plugin: PluginConstructor }
-				);
-			}
 		}
 
 		function getMissingPluginNames( plugins ) {

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -21,7 +21,7 @@ export default class PluginCollection {
 	 *
 	 * @param {module:core/editor/editor~Editor} editor
 	 * @param {Array.<Function>} [availablePlugins] Plugins (constructors) which the collection will be able to use
-	 * when {@link module:core/plugin~PluginCollection#load} is used with plugin names (strings, instead of constructors).
+	 * when {@link module:core/plugincollection~PluginCollection#load} is used with plugin names (strings, instead of constructors).
 	 * Usually, the editor will pass its built-in plugins to the collection so they can later be
 	 * used in `config.plugins` or `config.removePlugins` by names.
 	 */
@@ -69,8 +69,8 @@ export default class PluginCollection {
 	/**
 	 * Gets the plugin instance by its constructor or name.
 	 *
-	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~Plugin.pluginName name}.
-	 * @returns {module:core/plugin~Plugin}
+	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
+	 * @returns {module:core/plugin~PluginInterface}
 	 */
 	get( key ) {
 		return this._plugins.get( key );
@@ -79,14 +79,14 @@ export default class PluginCollection {
 	/**
 	 * Loads a set of plugins and adds them to the collection.
 	 *
-	 * @param {Array.<Function|String>} plugins An array of {@link module:core/plugin~Plugin plugin constructors}
-	 * or {@link module:core/plugin~Plugin.pluginName plugin names}. The second option (names) work only if
+	 * @param {Array.<Function|String>} plugins An array of {@link module:core/plugin~PluginInterface plugin constructors}
+	 * or {@link module:core/plugin~PluginInterface.pluginName plugin names}. The second option (names) work only if
 	 * `availablePlugins` were passed to the {@link #constructor}.
 	 * @param {Array.<String|Function>} [removePlugins] Names of plugins or plugin constructors
 	 * which should not be loaded (despite being specified in the `plugins` array).
 	 * @returns {Promise} A promise which gets resolved once all plugins are loaded and available into the
 	 * collection.
-	 * @returns {Promise.<Array.<module:core/plugin~Plugin>>} returns.loadedPlugins The array of loaded plugins.
+	 * @returns {Promise.<Array.<module:core/plugin~PluginInterface>>} returns.loadedPlugins The array of loaded plugins.
 	 */
 	load( plugins, removePlugins = [] ) {
 		const that = this;
@@ -194,7 +194,7 @@ export default class PluginCollection {
 		function assertIsPlugin( PluginConstructor ) {
 			if ( !( PluginConstructor.prototype instanceof Plugin ) ) {
 				/**
-				 * The loaded plugin module is not an instance of {@link module:core/plugin~Plugin}.
+				 * The loaded plugin module is not an instance of {@link module:core/plugin~PluginInterface}.
 				 *
 				 * @error plugincollection-instance
 				 * @param {*} plugin The constructor which is meant to be loaded as a plugin.
@@ -230,7 +230,7 @@ export default class PluginCollection {
 	 *
 	 * @protected
 	 * @param {Function} PluginConstructor The plugin constructor.
-	 * @param {module:core/plugin~Plugin} plugin The instance of the plugin.
+	 * @param {module:core/plugin~PluginInterface} plugin The instance of the plugin.
 	 */
 	_add( PluginConstructor, plugin ) {
 		this._plugins.set( PluginConstructor, plugin );

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -19,23 +19,3 @@ describe( 'constructor()', () => {
 		expect( plugin ).to.have.property( 'editor' ).to.equal( editor );
 	} );
 } );
-
-describe( 'init', () => {
-	it( 'should exist and do nothing', () => {
-		const plugin = new Plugin( editor );
-
-		expect( plugin.init ).to.be.a( 'function' );
-
-		plugin.init();
-	} );
-} );
-
-describe( 'destroy', () => {
-	it( 'should exist and do nothing', () => {
-		const plugin = new Plugin( editor );
-
-		expect( plugin.destroy ).to.be.a( 'function' );
-
-		plugin.destroy();
-	} );
-} );

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -18,4 +18,12 @@ describe( 'constructor()', () => {
 
 		expect( plugin ).to.have.property( 'editor' ).to.equal( editor );
 	} );
+
+	describe( 'destroy()', () => {
+		it( 'should be defined', () => {
+			const plugin = new Plugin( editor );
+
+			expect( plugin.destroy ).to.be.a( 'function' );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `PluginCollection` handles with plugins which do not extend the base `Plugin` class. Introduced `PluginInterface`. Closes ckeditor/ckeditor5#2913.

`init()`, `afterInit()` and `destroy()` methods for plugins are optional now.