### PR TITLE
T/85: Use a simpler plugin naming scheme

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -108,17 +108,18 @@ mix( Plugin, ObservableMixin );
  * {@link module:core/plugincollection~PluginCollection#get} by its
  * name and its constructor. If not, then only by its constructor.
  *
- * The name should reflect the package name + the plugin module name. E.g. `ckeditor5-image/src/image.js` plugin
- * should be named `image/image`. If plugin is kept deeper in the directory structure, it's recommended to only use the module file name,
- * not the whole path. So, e.g. a plugin defined in `ckeditor5-ui/src/notification/notification.js` file may be named `ui/notification`.
+ * The name should reflect the constructor name.
  *
  * To keep a plugin class definition tight it's recommended to define this property as a static getter:
  *
  *		export default class ImageCaption {
  *			static get pluginName() {
- *				return 'image/imagecaption';
+ *				return 'ImageCaption';
  *			}
  *		}
+ *
+ * Note: The native `Function.name` property could not be used to keep the plugin name because
+ * it will be mangled during code minification.
  *
  * @static
  * @readonly

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -45,25 +45,11 @@ export default class PluginCollection {
 		 */
 		this._plugins = new Map();
 
-		/**
-		 * Set of plugins' names. Used to detect whether tries to load a plugin with the same name.
-		 *
-		 * @protected
-		 * @type {Set} module:core/plugin~PluginCollection#_loadedPluginNames
-		 */
-		this._loadedPluginNames = new Set();
-
 		for ( const PluginConstructor of availablePlugins ) {
 			this._availablePlugins.set( PluginConstructor, PluginConstructor );
 
-			const pluginName = PluginConstructor.pluginName;
-
-			if ( pluginName ) {
-				if ( this._availablePlugins.has( pluginName ) ) {
-					log.warn( `Plugin "${ pluginName }" is already defined. Skipping.` );
-				} else {
-					this._availablePlugins.set( pluginName, PluginConstructor );
-				}
+			if ( PluginConstructor.pluginName ) {
+				this._availablePlugins.set( PluginConstructor.pluginName, PluginConstructor );
 			}
 		}
 	}
@@ -145,12 +131,6 @@ export default class PluginCollection {
 				return;
 			}
 
-			const pluginName = PluginConstructor.pluginName;
-
-			if ( pluginName && that._loadedPluginNames.has( pluginName ) ) {
-				log.warn( `Plugin "${ pluginName }" is already loaded. You should not load more than one plugin with the same name.` );
-			}
-
 			return instantiatePlugin( PluginConstructor )
 				.catch( err => {
 					/**
@@ -168,10 +148,6 @@ export default class PluginCollection {
 		function instantiatePlugin( PluginConstructor ) {
 			return new Promise( resolve => {
 				loading.add( PluginConstructor );
-
-				if ( PluginConstructor.pluginName ) {
-					that._loadedPluginNames.add( PluginConstructor.pluginName );
-				}
 
 				if ( PluginConstructor.requires ) {
 					PluginConstructor.requires.forEach( RequiredPluginConstructorOrName => {
@@ -257,7 +233,13 @@ export default class PluginCollection {
 
 		const pluginName = PluginConstructor.pluginName;
 
-		if ( pluginName && !this._plugins.has( pluginName ) ) {
+		if ( !pluginName ) {
+			return;
+		}
+
+		if ( this._plugins.has( pluginName ) ) {
+			log.warn( `Plugin "${ pluginName }" is already loaded. You should not load more than one plugin with the same name.` );
+		} else {
 			this._plugins.set( pluginName, plugin );
 		}
 	}

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -238,7 +238,20 @@ export default class PluginCollection {
 		}
 
 		if ( this._plugins.has( pluginName ) ) {
-			log.warn( `Plugin "${ pluginName }" is already loaded. You should not load more than one plugin with the same name.` );
+			/**
+			 * Two plugins with the same {@link module:core/plugin~PluginInterface.pluginName} were loaded.
+			 * This may lead to runtime conflicts between these plugins. This usually means that incorrect
+			 * params were passed to {@link module:core/editor/editor~Editor.create}.
+			 *
+			 * @error plugincollection-plugin-name-conflict
+			 * @param {String} pluginName The duplicated plugin name.
+			 * @param {Function} plugin1 The first plugin constructor.
+			 * @param {Function} plugin2 The second plugin constructor.
+			 */
+			log.warn(
+				'plugincollection-plugin-name-conflict: Two plugins with the same name were loaded.',
+				{ pluginName, plugin1: this._plugins.get( pluginName ).constructor, plugin2: PluginConstructor }
+			);
 		} else {
 			this._plugins.set( pluginName, plugin );
 		}

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -369,9 +369,12 @@ describe( 'PluginCollection', () => {
 					expect( plugins.get( AnotherPluginFoo ) ).to.be.an.instanceof( AnotherPluginFoo );
 
 					expect( logSpy.calledOnce ).to.equal( true );
-					expect( logSpy.firstCall.args[ 0 ] ).to.equal(
-						'Plugin "Foo" is already loaded. You should not load more than one plugin with the same name.'
-					);
+					expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-name-conflict:/ );
+
+					const warnData = logSpy.firstCall.args[ 1 ];
+					expect( warnData.pluginName ).to.equal( 'Foo' );
+					expect( warnData.plugin1 ).to.equal( PluginFoo );
+					expect( warnData.plugin2 ).to.equal( AnotherPluginFoo );
 				} );
 		} );
 
@@ -390,9 +393,7 @@ describe( 'PluginCollection', () => {
 					expect( plugins.get( PluginFoo ) ).to.be.an.instanceof( PluginFoo );
 
 					expect( logSpy.calledOnce ).to.equal( true );
-					expect( logSpy.firstCall.args[ 0 ] ).to.equal(
-						'Plugin "Foo" is already loaded. You should not load more than one plugin with the same name.'
-					);
+					expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-name-conflict:/ );
 				} );
 		} );
 
@@ -413,9 +414,7 @@ describe( 'PluginCollection', () => {
 						expect( plugins.get( AnotherPluginFoo ) ).to.be.an.instanceof( AnotherPluginFoo );
 
 						expect( logSpy.calledOnce ).to.equal( true );
-						expect( logSpy.firstCall.args[ 0 ] ).to.equal(
-							'Plugin "Foo" is already loaded. You should not load more than one plugin with the same name.'
-						);
+						expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-name-conflict:/ );
 					} );
 			}
 		);

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -73,22 +73,6 @@ describe( 'PluginCollection', () => {
 		PluginFoo.requires = [];
 	} );
 
-	describe( 'constructor()', () => {
-		it( 'logs if passed an array that contains plugins with duplicated names as available plugins', () => {
-			availablePlugins = [ PluginFoo, AnotherPluginFoo ];
-
-			const logSpy = testUtils.sinon.stub( log, 'warn' );
-			const plugins = new PluginCollection( editor, availablePlugins );
-
-			expect( logSpy.firstCall.args[ 0 ] ).to.equal( 'Plugin "Foo" is already defined. Skipping.' );
-
-			expect( plugins._availablePlugins.size ).to.equal( 3 );
-			expect( plugins._availablePlugins.get( 'Foo' ) ).to.equal( PluginFoo );
-			expect( plugins._availablePlugins.get( PluginFoo ) ).to.equal( PluginFoo );
-			expect( plugins._availablePlugins.get( AnotherPluginFoo ) ).to.equal( AnotherPluginFoo );
-		} );
-	} );
-
 	describe( 'load()', () => {
 		it( 'should not fail when trying to load 0 plugins (empty array)', () => {
 			const plugins = new PluginCollection( editor, availablePlugins );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `PluginCollection` will warning if a user wants to load two or more plugins with the same name. Closes ckeditor/ckeditor5#2914.

---

### Additional information

* List of packages that plugins have changed their names: https://github.com/ckeditor/ckeditor5-core/issues/85#issuecomment-312517286, https://github.com/ckeditor/ckeditor5-core/issues/85#issuecomment-312551986.
* [Build on CI which uses new plugin names](https://github.com/ckeditor/ckeditor5-core/issues/85#issuecomment-312561882).
