### PR TITLE
Bound EditingController#isReadOnly to the editor

### DIFF
--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -39,6 +39,7 @@ export default class StandardEditor extends Editor {
 
 		// Documented in Editor.
 		this.editing = new EditingController( this.document );
+		this.editing.bind( 'isReadOnly' ).to( this );
 
 		/**
 		 * Instance of the {@link module:core/editingkeystrokehandler~EditingKeystrokeHandler}.

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -31,6 +31,18 @@ describe( 'StandardEditor', () => {
 			expect( editor.keystrokes ).to.be.instanceof( EditingKeystrokeHandler );
 		} );
 
+		it( 'should bind editing#isReadOnly to the editor', () => {
+			const editor = new StandardEditor( editorElement, { foo: 1 } );
+
+			editor.isReadOnly = false;
+
+			expect( editor.editing.isReadOnly ).to.false;
+
+			editor.isReadOnly = true;
+
+			expect( editor.editing.isReadOnly ).to.true;
+		} );
+
 		it( 'activates #keystrokes', () => {
 			const spy = sinon.spy( EditingKeystrokeHandler.prototype, 'listenTo' );
 			const editor = new StandardEditor( editorElement, { foo: 1 } );

--- a/tests/manual/readonly.md
+++ b/tests/manual/readonly.md
@@ -6,6 +6,5 @@
 4. Check if modifying content is blocked (input, delete, paste) for collapsed and non-collapsed selection.
 5. Check if toolbar buttons are disabled.
 6. Check if toolbar buttons reflect selection attributes (eg. when selection is in bold text then bold button should be on).
-7. Check 5 and 6 for the ContextualToolbar.
-8. Check if link balloon panel opens in read-only mode.
-9. Check if image text alternative balloon opens in read-only mode.
+7. Check if link balloon panel opens in read-only mode.
+8. Check if image text alternative balloon opens in read-only mode.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Bound `EditingController#isReadOnly` to the editor. Closes ckeditor/ckeditor5#2922.

---

### Requires:
- https://github.com/ckeditor/ckeditor5-engine/pull/1025