### PR TITLE
Bound view Document#isReadOnly directly to the Editor#isReadOnly omitting EditingController

### DIFF
--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -39,7 +39,7 @@ export default class StandardEditor extends Editor {
 
 		// Documented in Editor.
 		this.editing = new EditingController( this.document );
-		this.editing.bind( 'isReadOnly' ).to( this );
+		this.editing.view.bind( 'isReadOnly' ).to( this );
 
 		/**
 		 * Instance of the {@link module:core/editingkeystrokehandler~EditingKeystrokeHandler}.

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -31,16 +31,16 @@ describe( 'StandardEditor', () => {
 			expect( editor.keystrokes ).to.be.instanceof( EditingKeystrokeHandler );
 		} );
 
-		it( 'should bind editing#isReadOnly to the editor', () => {
+		it( 'should bind editing.view#isReadOnly to the editor', () => {
 			const editor = new StandardEditor( editorElement, { foo: 1 } );
 
 			editor.isReadOnly = false;
 
-			expect( editor.editing.isReadOnly ).to.false;
+			expect( editor.editing.view.isReadOnly ).to.false;
 
 			editor.isReadOnly = true;
 
-			expect( editor.editing.isReadOnly ).to.true;
+			expect( editor.editing.view.isReadOnly ).to.true;
 		} );
 
 		it( 'activates #keystrokes', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Bound view `Document#isReadOnly` directly to the `Editor#isReadOnly` omitting `EditingController` (see https://github.com/ckeditor/ckeditor5-engine/issues/1028).

---

Requires: https://github.com/ckeditor/ckeditor5-engine/pull/1030