### PR TITLE
t/ckeditor5/447: EditingKeystrokeHandler should support priorities and proper canceling

### DIFF
--- a/src/editingkeystrokehandler.js
+++ b/src/editingkeystrokehandler.js
@@ -52,6 +52,10 @@ export default class EditingKeystrokeHandler extends KeystrokeHandler {
 	 * If a function, then it will be called with the
 	 * {@link module:engine/view/observer/keyobserver~KeyEventData key event data} object and
 	 * a `cancel()` helper to both `preventDefault()` and `stopPropagation()` of the event.
+	 * @param {Object} [options={}] Additional options.
+	 * @param {module:utils/priorities~PriorityString|Number} [options.priority='normal'] The priority of the keystroke
+	 * callback. The higher the priority value the sooner the callback will be executed. Keystrokes having the same priority
+	 * are called in the order they were added.
 	 */
 	set( keystroke, callback, options = {} ) {
 		if ( typeof callback == 'string' ) {

--- a/src/editingkeystrokehandler.js
+++ b/src/editingkeystrokehandler.js
@@ -53,7 +53,7 @@ export default class EditingKeystrokeHandler extends KeystrokeHandler {
 	 * {@link module:engine/view/observer/keyobserver~KeyEventData key event data} object and
 	 * a `cancel()` helper to both `preventDefault()` and `stopPropagation()` of the event.
 	 */
-	set( keystroke, callback ) {
+	set( keystroke, callback, options = {} ) {
 		if ( typeof callback == 'string' ) {
 			const commandName = callback;
 
@@ -63,6 +63,6 @@ export default class EditingKeystrokeHandler extends KeystrokeHandler {
 			};
 		}
 
-		super.set( keystroke, callback );
+		super.set( keystroke, callback, options );
 	}
 }

--- a/tests/editingkeystrokehandler.js
+++ b/tests/editingkeystrokehandler.js
@@ -41,6 +41,25 @@ describe( 'EditingKeystrokeHandler', () => {
 				sinon.assert.notCalled( keyEvtData.preventDefault );
 				sinon.assert.notCalled( keyEvtData.stopPropagation );
 			} );
+
+			it( 'provides a callback which stops the event and remaining callbacks in the keystroke handler', () => {
+				const spy1 = sinon.spy();
+				const spy2 = sinon.spy();
+				const spy3 = sinon.spy();
+
+				keystrokes.set( [ 'ctrl', 'A' ], spy1 );
+				keystrokes.set( [ 'ctrl', 'A' ], spy2, { priority: 'high' } );
+				keystrokes.set( [ 'ctrl', 'A' ], 'foo', { priority: 'low' } );
+				keystrokes.set( [ 'ctrl', 'A' ], ( keyEvtData, cancel ) => {
+					spy3();
+					cancel();
+				} );
+
+				keystrokes.press( getCtrlA() );
+
+				sinon.assert.callOrder( spy2, spy1, spy3 );
+				sinon.assert.notCalled( executeSpy );
+			} );
 		} );
 
 		describe( 'with a callback', () => {
@@ -55,6 +74,21 @@ describe( 'EditingKeystrokeHandler', () => {
 				sinon.assert.notCalled( keyEvtData.preventDefault );
 				sinon.assert.notCalled( keyEvtData.stopPropagation );
 			} );
+		} );
+
+		it( 'supports priorities', () => {
+			const spy1 = sinon.spy();
+			const spy2 = sinon.spy();
+			const spy3 = sinon.spy();
+
+			keystrokes.set( [ 'ctrl', 'A' ], spy1 );
+			keystrokes.set( [ 'ctrl', 'A' ], spy2, { priority: 'high' } );
+			keystrokes.set( [ 'ctrl', 'A' ], 'foo', { priority: 'low' } );
+			keystrokes.set( [ 'ctrl', 'A' ], spy3 );
+
+			keystrokes.press( getCtrlA() );
+
+			sinon.assert.callOrder( spy2, spy1, spy3, executeSpy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: EditingKeystrokeHandler should support priorities and proper canceling. Closes ckeditor/ckeditor5#2924.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-utils/pull/181.
* A follow-up of https://github.com/ckeditor/ckeditor5/issues/447#issuecomment-320698055.