### PR TITLE
Fixed broken tests (BrowserStack)

### DIFF
--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -345,6 +345,9 @@ describe( 'StandardEditor', () => {
 		} );
 
 		it( 'should not replace submit() method when one of the elements in a form is named "submit"', () => {
+			// Restore stub since we want to mask submit function with input with name="submit".
+			submitStub.restore();
+
 			const input = document.createElement( 'input' );
 			input.setAttribute( 'name', 'submit' );
 			form.appendChild( input );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Restored stub since we want to mask submit function with element `input[name="submit"]`. Closes ckeditor/ckeditor5#2926.

---

![image](https://user-images.githubusercontent.com/2270764/32319154-dd2c3374-bfb9-11e7-94d2-75aaf739e9cf.png)
