### PR TITLE
Change `config.lang` to `config.languages` to align naming convention

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -63,7 +63,7 @@ export default class Editor {
 		 * @readonly
 		 * @member {module:utils/locale~Locale}
 		 */
-		this.locale = new Locale( this.config.get( 'lang' ) );
+		this.locale = new Locale( this.config.get( 'language' ) );
 
 		/**
 		 * Shorthand for {@link module:utils/locale~Locale#t}.

--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -106,3 +106,35 @@
  *
  * @member {Array.<String>|Object} module:core/editor/editorconfig~EditorConfig#toolbar
  */
+
+/**
+ * Editor UI's language.
+ *
+ * The language code is defined in the [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) standard.
+ * CKEditor 5 currently supports around 20 languages and the number is growing.
+ *
+ * Note: You don't have to specify this option if your build is optimized for one language or if it's the default language
+ * (English is the default language for CDN builds).
+ *
+ * Simple usage:
+ *
+ *		ClassicEditor
+ *			.create( document.querySelector( '#editor' ), {
+ *				language: 'de'
+ *			} )
+ *			.then( editor => {
+ *				console.log( editor );
+ *			} )
+ *			.catch( error => {
+ *				console.error( error );
+ *			} );
+ *
+ * After this step you need to attach the corresponding translation file. Translation files are available at CDN for predefined builds:
+ *		`<script src="https://cdn.ckeditor.com/ckeditor5/[version.number]/[distribution]/lang/[lang].js"></script>`
+ *
+ * But you can add them manually by coping from the `node_modules/@ckeditor/ckeditor5-build-[name]/build/lang/[lang].js'`.
+ *
+ * Check the {@glink features/ui-language UI language guide} for more information about the localization options and translation process.
+ *
+ * @member {String} module:core/editor/editorconfig~EditorConfig#language
+ */

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -151,10 +151,10 @@ describe( 'Editor', () => {
 			expect( editor.t ).to.equal( editor.locale.t );
 		} );
 
-		it( 'is configured with the config.lang', () => {
-			const editor = new Editor( { lang: 'pl' } );
+		it( 'is configured with the config.language', () => {
+			const editor = new Editor( { language: 'pl' } );
 
-			expect( editor.locale.lang ).to.equal( 'pl' );
+			expect( editor.locale.language ).to.equal( 'pl' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Changed `config.lang` to `config.languages` to align naming convention. Part of the Translation Service v2.

---

### Additional information

BREAKING CHANGES: Editor's config `config.lang` became `config.languages`.