### PR TITLE
Cleaned up Editor classes

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -20,14 +20,9 @@ import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
- * Class representing editor. It contains basic editor architecture and provides API needed by plugins
- * like {@link module:engine/controller/editingcontroller~EditingController editing pipeline},
- * {@link module:engine/controller/datacontroller~DataController data pipeline} and
- * {module:core/editingkeystrokehandler~EditingKeystrokeHandler keystroke handler}.
- *
- * Besides it creates main {@link module:engine/model/rootelement~RootElement} using
- * {@link module:engine/model/document~Document#createRoot createRoot} method what automatically creates
- * corresponding {@link module:engine/view/rooteditableelement~RootEditableElement view root} element.
+ * Class representing the base of the editor. It is the API all plugins can expect to get when using editor property.
+ * Editors implementation (like Classic Editor or Inline Editor) should extend this class. They can add their own
+ * methods and properties.
  *
  * See also {@link module:core/editor/standardeditor~StandardEditor}.
  *

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -14,14 +14,16 @@ import CommandCollection from '../commandcollection';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 import DataController from '@ckeditor/ckeditor5-engine/src/controller/datacontroller';
 import Model from '@ckeditor/ckeditor5-engine/src/model/model';
+import EditingKeystrokeHandler from '../editingkeystrokehandler';
 
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
  * Class representing editor. It contains basic editor architecture and provides API needed by plugins
- * like {@link module:engine/controller/editingcontroller~EditingController editing pipeline} and
- * {@link module:engine/controller/datacontroller~DataController data pipeline}.
+ * like {@link module:engine/controller/editingcontroller~EditingController editing pipeline},
+ * {@link module:engine/controller/datacontroller~DataController data pipeline} and
+ * {module:core/editingkeystrokehandler~EditingKeystrokeHandler keystroke handler}.
  *
  * Besides it creates main {@link module:engine/model/rootelement~RootElement} using
  * {@link module:engine/model/document~Document#createRoot createRoot} method what automatically creates
@@ -122,6 +124,15 @@ export default class Editor {
 		 */
 		this.editing = new EditingController( this.model );
 		this.editing.view.bind( 'isReadOnly' ).to( this );
+
+		/**
+		 * Instance of the {@link module:core/editingkeystrokehandler~EditingKeystrokeHandler}.
+		 *
+		 * @readonly
+		 * @member {module:core/editingkeystrokehandler~EditingKeystrokeHandler}
+		 */
+		this.keystrokes = new EditingKeystrokeHandler( this );
+		this.keystrokes.listenTo( this.editing.view );
 	}
 
 	/**
@@ -176,6 +187,7 @@ export default class Editor {
 				this.model.destroy();
 				this.data.destroy();
 				this.editing.destroy();
+				this.keystrokes.destroy();
 			} );
 	}
 

--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -8,14 +8,13 @@
  */
 
 import Editor from './editor';
-import EditingKeystrokeHandler from '../editingkeystrokehandler';
 import isFunction from '@ckeditor/ckeditor5-utils/src/lib/lodash/isFunction';
 
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 
 /**
- * Class representing a typical browser-based editor.
+ * Class provides API methods for getting and setting data.
  *
  * @extends module:core/editor/editor~Editor
  */
@@ -39,14 +38,6 @@ export default class StandardEditor extends Editor {
 		this.element = element;
 
 		/**
-		 * Instance of the {@link module:core/editingkeystrokehandler~EditingKeystrokeHandler}.
-		 *
-		 * @readonly
-		 * @member {module:core/editingkeystrokehandler~EditingKeystrokeHandler}
-		 */
-		this.keystrokes = new EditingKeystrokeHandler( this );
-
-		/**
 		 * Editor UI instance.
 		 *
 		 * This property is set by more specialized editor constructors. However, it's required
@@ -57,18 +48,7 @@ export default class StandardEditor extends Editor {
 		 * @member {module:core/editor/editorui~EditorUI} #ui
 		 */
 
-		this.keystrokes.listenTo( this.editing.view );
-
 		this._attachToForm();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	destroy() {
-		return Promise.resolve()
-			.then( () => this.keystrokes.destroy() )
-			.then( super.destroy() );
 	}
 
 	/**

--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -14,7 +14,10 @@ import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromele
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 
 /**
- * Class provides API methods for getting and setting data.
+ * The standard editor class, extending base editor by adding methods needed in the typical
+ * editor implementations: editor with a single editable area created based on the DOM element.
+ * It provides base API to manage data and to integrate the editor with the form when it is
+ * initialized on the textarea element.
  *
  * @extends module:core/editor/editor~Editor
  */

--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -9,15 +9,13 @@
 
 import Editor from './editor';
 import EditingKeystrokeHandler from '../editingkeystrokehandler';
-import EditingController from '@ckeditor/ckeditor5-engine/src/controller/editingcontroller';
 import isFunction from '@ckeditor/ckeditor5-utils/src/lib/lodash/isFunction';
 
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 
 /**
- * Class representing a typical browser-based editor. It handles a single source element and
- * uses {@link module:engine/controller/editingcontroller~EditingController}.
+ * Class representing a typical browser-based editor.
  *
  * @extends module:core/editor/editor~Editor
  */
@@ -39,10 +37,6 @@ export default class StandardEditor extends Editor {
 		 * @member {HTMLElement}
 		 */
 		this.element = element;
-
-		// Documented in Editor.
-		this.editing = new EditingController( this.model );
-		this.editing.view.bind( 'isReadOnly' ).to( this );
 
 		/**
 		 * Instance of the {@link module:core/editingkeystrokehandler~EditingKeystrokeHandler}.
@@ -74,7 +68,6 @@ export default class StandardEditor extends Editor {
 	destroy() {
 		return Promise.resolve()
 			.then( () => this.keystrokes.destroy() )
-			.then( () => this.editing.destroy() )
 			.then( super.destroy() );
 	}
 

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -37,13 +37,6 @@ describe( 'ClassicTestEditor', () => {
 			expect( editor.element ).to.equal( editorElement );
 			expect( editor.ui ).to.be.instanceOf( ClassicTestEditorUI );
 			expect( editor.ui.view ).to.be.instanceOf( BoxedEditorUIView );
-		} );
-
-		it( 'creates model and view roots', () => {
-			const editor = new ClassicTestEditor( editorElement );
-
-			expect( editor.model.document.getRoot() ).to.have.property( 'name', '$root' );
-			expect( editor.editing.view.getRoot() ).to.have.property( 'name', 'div' );
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
 		} );
 

--- a/tests/_utils-tests/modeltesteditor.js
+++ b/tests/_utils-tests/modeltesteditor.js
@@ -21,15 +21,22 @@ describe( 'ModelTestEditor', () => {
 			const editor = new ModelTestEditor( { foo: 1 } );
 
 			expect( editor ).to.be.instanceof( Editor );
-
 			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
+			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
 		} );
 
-		it( 'creates model and view roots', () => {
+		it( 'creates model root', () => {
 			const editor = new ModelTestEditor( { foo: 1 } );
 
 			expect( editor.model.document.getRoot() ).to.have.property( 'name', '$root' );
-			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
+		} );
+
+		it( 'should disable editing pipeline and clear main root', () => {
+			const editor = new ModelTestEditor( { foo: 1 } );
+
+			editor.model.document.createRoot( 'second', 'second' );
+
+			expect( Array.from( editor.editing.view.roots ) ).to.length( 0 );
 		} );
 	} );
 

--- a/tests/_utils-tests/virtualtesteditor.js
+++ b/tests/_utils-tests/virtualtesteditor.js
@@ -19,16 +19,8 @@ describe( 'VirtualTestEditor', () => {
 			const editor = new VirtualTestEditor( { foo: 1 } );
 
 			expect( editor ).to.be.instanceof( StandardEditor );
-
-			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
-		} );
-
-		it( 'creates model and view roots', () => {
-			const editor = new VirtualTestEditor( { foo: 1 } );
-
-			expect( editor.model.document.getRoot() ).to.have.property( 'name', '$root' );
-			expect( editor.editing.view.getRoot() ).to.have.property( 'name', 'div' );
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
+			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
 		} );
 	} );
 

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -23,8 +23,6 @@ export default class ClassicTestEditor extends StandardEditor {
 	constructor( element, config ) {
 		super( element, config );
 
-		this.model.document.createRoot();
-		this.editing.createRoot( 'div' );
 		this.data.processor = new HtmlDataProcessor();
 
 		this.ui = new ClassicTestEditorUI( this, new BoxedEditorUIView( this.locale ) );

--- a/tests/_utils/modeltesteditor.js
+++ b/tests/_utils/modeltesteditor.js
@@ -18,9 +18,11 @@ export default class ModelTestEditor extends Editor {
 	constructor( config ) {
 		super( config );
 
-		this.model.document.createRoot();
-
 		this.data.processor = new HtmlDataProcessor();
+
+		// Disable editing pipeline for model editor.
+		this.editing.destroy();
+		this.editing.view.roots.clear();
 	}
 
 	/**

--- a/tests/_utils/virtualtesteditor.js
+++ b/tests/_utils/virtualtesteditor.js
@@ -19,10 +19,6 @@ export default class VirtualTestEditor extends StandardEditor {
 		super( null, config );
 
 		this.data.processor = new HtmlDataProcessor();
-
-		// Lets change view root element name from $root to div.
-		// This will look more friendly in view tests.
-		this.editing.view.getRoot().name = 'div';
 	}
 
 	/**

--- a/tests/_utils/virtualtesteditor.js
+++ b/tests/_utils/virtualtesteditor.js
@@ -18,11 +18,11 @@ export default class VirtualTestEditor extends StandardEditor {
 	constructor( config ) {
 		super( null, config );
 
-		this.model.document.createRoot();
-
-		this.editing.createRoot( 'div' );
-
 		this.data.processor = new HtmlDataProcessor();
+
+		// Lets change view root element name from $root to div.
+		// This will look more friendly in view tests.
+		this.editing.view.getRoot().name = 'div';
 	}
 
 	/**

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -8,6 +8,7 @@
 import Editor from '../../src/editor/editor';
 import Plugin from '../../src/plugin';
 import Config from '@ckeditor/ckeditor5-utils/src/config';
+import EditingController from '@ckeditor/ckeditor5-engine/src/controller/editingcontroller';
 import PluginCollection from '../../src/plugincollection';
 import CommandCollection from '../../src/commandcollection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
@@ -103,6 +104,7 @@ describe( 'Editor', () => {
 
 			expect( editor.config ).to.be.an.instanceof( Config );
 			expect( editor.commands ).to.be.an.instanceof( CommandCollection );
+			expect( editor.editing ).to.be.instanceof( EditingController );
 
 			expect( editor.plugins ).to.be.an.instanceof( PluginCollection );
 			expect( getPlugins( editor ) ).to.be.empty;
@@ -132,6 +134,24 @@ describe( 'Editor', () => {
 			} );
 
 			expect( editor.config.get( 'bar' ) ).to.equal( 'foo' );
+		} );
+
+		it( 'should bind editing.view#isReadOnly to the editor', () => {
+			const editor = new Editor();
+
+			editor.isReadOnly = false;
+
+			expect( editor.editing.view.isReadOnly ).to.false;
+
+			editor.isReadOnly = true;
+
+			expect( editor.editing.view.isReadOnly ).to.true;
+		} );
+
+		it( 'should create main root element', () => {
+			const editor = new Editor();
+
+			expect( editor.model.document.hasRoot( 'main' ) ).to.true;
 		} );
 	} );
 
@@ -194,13 +214,15 @@ describe( 'Editor', () => {
 
 			const spy1 = sinon.spy( editor.data, 'destroy' );
 			const spy2 = sinon.spy( editor.model, 'destroy' );
-			const spy3 = sinon.spy( editor.plugins, 'destroy' );
+			const spy3 = sinon.spy( editor.editing, 'destroy' );
+			const spy4 = sinon.spy( editor.plugins, 'destroy' );
 
 			return editor.destroy()
 				.then( () => {
 					expect( spy1.calledOnce ).to.be.true;
 					expect( spy2.calledOnce ).to.be.true;
 					expect( spy3.calledOnce ).to.be.true;
+					expect( spy4.calledOnce ).to.be.true;
 				} );
 		} );
 	} );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -153,7 +153,7 @@ describe( 'Editor', () => {
 		it( 'should create main root element', () => {
 			const editor = new Editor();
 
-			expect( editor.model.document.hasRoot( 'main' ) ).to.true;
+			expect( editor.model.document.getRoot( 'main' ) ).to.ok;
 		} );
 
 		it( 'should activate #keystrokes', () => {

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -14,6 +14,7 @@ import CommandCollection from '../../src/commandcollection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 import Command from '../../src/command';
+import EditingKeystrokeHandler from '../../src/editingkeystrokehandler';
 
 class PluginA extends Plugin {
 	constructor( editor ) {
@@ -105,6 +106,7 @@ describe( 'Editor', () => {
 			expect( editor.config ).to.be.an.instanceof( Config );
 			expect( editor.commands ).to.be.an.instanceof( CommandCollection );
 			expect( editor.editing ).to.be.instanceof( EditingController );
+			expect( editor.keystrokes ).to.be.instanceof( EditingKeystrokeHandler );
 
 			expect( editor.plugins ).to.be.an.instanceof( PluginCollection );
 			expect( getPlugins( editor ) ).to.be.empty;
@@ -152,6 +154,13 @@ describe( 'Editor', () => {
 			const editor = new Editor();
 
 			expect( editor.model.document.hasRoot( 'main' ) ).to.true;
+		} );
+
+		it( 'should activate #keystrokes', () => {
+			const spy = sinon.spy( EditingKeystrokeHandler.prototype, 'listenTo' );
+			const editor = new Editor();
+
+			sinon.assert.calledWith( spy, editor.editing.view );
 		} );
 	} );
 
@@ -212,17 +221,19 @@ describe( 'Editor', () => {
 		it( 'should destroy all components it initialized', () => {
 			const editor = new Editor();
 
-			const spy1 = sinon.spy( editor.data, 'destroy' );
-			const spy2 = sinon.spy( editor.model, 'destroy' );
-			const spy3 = sinon.spy( editor.editing, 'destroy' );
-			const spy4 = sinon.spy( editor.plugins, 'destroy' );
+			const dataDestroySpy = sinon.spy( editor.data, 'destroy' );
+			const modelDestroySpy = sinon.spy( editor.model, 'destroy' );
+			const editingDestroySpy = sinon.spy( editor.editing, 'destroy' );
+			const pluginsDestroySpy = sinon.spy( editor.plugins, 'destroy' );
+			const keystrokesDestroySpy = sinon.spy( editor.keystrokes, 'destroy' );
 
 			return editor.destroy()
 				.then( () => {
-					expect( spy1.calledOnce ).to.be.true;
-					expect( spy2.calledOnce ).to.be.true;
-					expect( spy3.calledOnce ).to.be.true;
-					expect( spy4.calledOnce ).to.be.true;
+					sinon.assert.calledOnce( dataDestroySpy );
+					sinon.assert.calledOnce( modelDestroySpy );
+					sinon.assert.calledOnce( editingDestroySpy );
+					sinon.assert.calledOnce( pluginsDestroySpy );
+					sinon.assert.calledOnce( keystrokesDestroySpy );
 				} );
 		} );
 	} );

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -10,7 +10,6 @@ import StandardEditor from '../../src/editor/standardeditor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
-import EditingController from '@ckeditor/ckeditor5-engine/src/controller/editingcontroller';
 import EditingKeystrokeHandler from '../../src/editingkeystrokehandler';
 import Plugin from '../../src/plugin';
 
@@ -27,20 +26,7 @@ describe( 'StandardEditor', () => {
 			const editor = new StandardEditor( editorElement, { foo: 1 } );
 
 			expect( editor ).to.have.property( 'element', editorElement );
-			expect( editor.editing ).to.be.instanceof( EditingController );
 			expect( editor.keystrokes ).to.be.instanceof( EditingKeystrokeHandler );
-		} );
-
-		it( 'should bind editing.view#isReadOnly to the editor', () => {
-			const editor = new StandardEditor( editorElement, { foo: 1 } );
-
-			editor.isReadOnly = false;
-
-			expect( editor.editing.view.isReadOnly ).to.false;
-
-			editor.isReadOnly = true;
-
-			expect( editor.editing.view.isReadOnly ).to.true;
 		} );
 
 		it( 'activates #keystrokes', () => {
@@ -67,18 +53,6 @@ describe( 'StandardEditor', () => {
 		it( 'destroys the #keystrokes', () => {
 			const editor = new StandardEditor( editorElement, { foo: 1 } );
 			const spy = sinon.spy( editor.keystrokes, 'destroy' );
-
-			sinon.assert.notCalled( spy );
-
-			return editor.destroy()
-				.then( () => {
-					sinon.assert.calledOnce( spy );
-				} );
-		} );
-
-		it( 'destroys the #editing', () => {
-			const editor = new StandardEditor( editorElement, { foo: 1 } );
-			const spy = sinon.spy( editor.editing, 'destroy' );
 
 			sinon.assert.notCalled( spy );
 
@@ -153,11 +127,7 @@ describe( 'StandardEditor', () => {
 		} );
 
 		it( 'should set data of the first root', () => {
-			editor.model.document.createRoot();
 			editor.model.document.createRoot( '$root', 'secondRoot' );
-
-			editor.editing.createRoot( 'div' );
-			editor.editing.createRoot( 'div', 'secondRoot' );
 
 			editor.setData( 'foo' );
 
@@ -180,11 +150,7 @@ describe( 'StandardEditor', () => {
 		} );
 
 		it( 'should get data of the first root', () => {
-			editor.model.document.createRoot();
 			editor.model.document.createRoot( '$root', 'secondRoot' );
-
-			editor.editing.createRoot( 'div' );
-			editor.editing.createRoot( 'div', 'secondRoot' );
 
 			setData( editor.model, 'foo' );
 

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -10,7 +10,6 @@ import StandardEditor from '../../src/editor/standardeditor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
-import EditingKeystrokeHandler from '../../src/editingkeystrokehandler';
 import Plugin from '../../src/plugin';
 
 describe( 'StandardEditor', () => {
@@ -26,14 +25,6 @@ describe( 'StandardEditor', () => {
 			const editor = new StandardEditor( editorElement, { foo: 1 } );
 
 			expect( editor ).to.have.property( 'element', editorElement );
-			expect( editor.keystrokes ).to.be.instanceof( EditingKeystrokeHandler );
-		} );
-
-		it( 'activates #keystrokes', () => {
-			const spy = sinon.spy( EditingKeystrokeHandler.prototype, 'listenTo' );
-			const editor = new StandardEditor( editorElement, { foo: 1 } );
-
-			sinon.assert.calledWith( spy, editor.editing.view );
 		} );
 
 		it( 'sets config', () => {
@@ -48,18 +39,6 @@ describe( 'StandardEditor', () => {
 			const editor = new StandardEditor( editorElement, { foo: 1 } );
 
 			expect( editor.destroy() ).to.be.an.instanceof( Promise );
-		} );
-
-		it( 'destroys the #keystrokes', () => {
-			const editor = new StandardEditor( editorElement, { foo: 1 } );
-			const spy = sinon.spy( editor.keystrokes, 'destroy' );
-
-			sinon.assert.notCalled( spy );
-
-			return editor.destroy()
-				.then( () => {
-					sinon.assert.calledOnce( spy );
-				} );
 		} );
 
 		it( 'destroys the parent', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Moved `EditingController`, `DataController` and `EditingKeystrokeHandler` from `StandardEditor` to `Editor` class. Closes ckeditor/ckeditor5#2928.
  
---
Constelation: https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-core/110

Requires:
- https://github.com/ckeditor/ckeditor5-engine/pull/1233
- https://github.com/ckeditor/ckeditor5-editor-balloon/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-editor-classic/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-editor-inline/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-clipboard/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-enter/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-paragraph/tree/t/ckeditor5-core/110
- https://github.com/ckeditor/ckeditor5-typing/tree/t/ckeditor5-core/110