### PR TITLE
 Removed loadDataFromElement method from ElementApiMixin.

### DIFF
--- a/src/editor/utils/elementapimixin.js
+++ b/src/editor/utils/elementapimixin.js
@@ -3,7 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 
 /**
@@ -22,13 +21,6 @@ const ElementApiMixin = {
 	 */
 	updateElement() {
 		setDataInElement( this.element, this.data.get() );
-	},
-
-	/**
-	 * @inheritDoc
-	 */
-	loadDataFromElement() {
-		this.data.set( getDataFromElement( this.element ) );
 	}
 };
 
@@ -51,10 +43,4 @@ export default ElementApiMixin;
  * Updates the {@link #element editor element}'s content with the data.
  *
  * @method #updateElement
- */
-
-/**
- * Loads the data from the {@link #element editor element} to the main root.
- *
- * @method #loadDataFromElement
  */

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -11,6 +11,7 @@ import ClassicTestEditorUI from './classictesteditorui';
 import BoxedEditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/boxed/boxededitoruiview';
 import ElementReplacer from '@ckeditor/ckeditor5-utils/src/elementreplacer';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
+import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
@@ -71,7 +72,7 @@ export default class ClassicTestEditor extends Editor {
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
-					.then( () => editor.loadDataFromElement() )
+					.then( () => editor.data.init( getDataFromElement( element ) ) )
 					.then( () => {
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/tests/editor/utils/elementapimixin.js
+++ b/tests/editor/utils/elementapimixin.js
@@ -27,23 +27,6 @@ describe( 'ElementApiMixin', () => {
 		editor.destroy();
 	} );
 
-	describe( 'loadDataFromElement()', () => {
-		it( 'should be added to editor interface', () => {
-			expect( editor ).have.property( 'loadDataFromElement' ).to.be.a( 'function' );
-		} );
-
-		it( 'sets data to editor element', () => {
-			const editorElement = document.createElement( 'div' );
-
-			editor.element = editorElement;
-			editorElement.innerHTML = 'foo bar';
-
-			editor.loadDataFromElement();
-
-			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
-		} );
-	} );
-
 	describe( 'updateEditorElement()', () => {
 		it( 'should be added to editor interface', () => {
 			expect( editor ).have.property( 'updateElement' ).to.be.a( 'function' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed `loadDataFromElement` method from `ElementApiMixin`. Closes ckeditor/ckeditor5#2932.

---

Requires:
- https://github.com/ckeditor/ckeditor5-engine/pull/1333
- https://github.com/ckeditor/ckeditor5-ui/tree/t/ckeditor5-core/120
- https://github.com/ckeditor/ckeditor5-editor-classic/tree/t/ckeditor5-core/120
- https://github.com/ckeditor/ckeditor5-editor-balloon/tree/t/ckeditor5-core/120
- https://github.com/ckeditor/ckeditor5-editor-inline/tree/t/ckeditor5-core/120