### PR TITLE
Feature: Introduced PendingActions plugin.

### DIFF
--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -61,6 +61,7 @@ export default class PendingActions extends Plugin {
 		 * @type {module:utils/collection~Collection}
 		 */
 		this._actions = new Collection( { idProperty: '_id' } );
+		this._actions.delegate( 'add', 'remove' ).to( this );
 
 		// It's not possible to easy test it because karma uses `beforeunload` event
 		// to warn before full page reload and this event cannot be dispatched manually.
@@ -110,8 +111,25 @@ export default class PendingActions extends Plugin {
 		return this._actions[ Symbol.iterator ]();
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 		this._domEmitter.stopListening();
 	}
+
+	/**
+	 * Fired when an action is added to the list.
+	 *
+	 * @event add
+	 * @param {Object} action The added action.
+	 */
+
+	/**
+	 * Fired when an action is removed from the list.
+	 *
+	 * @event remove
+	 * @param {Object} action The removed action.
+	 */
 }

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -75,7 +75,7 @@ export default class PendingActions extends Plugin {
 		/* istanbul ignore next */
 		this._domEmitter.listenTo( window, 'beforeunload', ( evtInfo, domEvt ) => {
 			if ( this.isPending ) {
-				domEvt.returnValue = this._actions.get( 0 ).message;
+				domEvt.returnValue = this.first.message;
 			}
 		} );
 	}
@@ -115,6 +115,15 @@ export default class PendingActions extends Plugin {
 	remove( action ) {
 		this._actions.remove( action );
 		this.isPending = !!this._actions.length;
+	}
+
+	/**
+	 * Returns first action from the list.
+	 *
+	 * returns {Object} Pending action object.
+	 */
+	get first() {
+		return this._actions.get( 0 );
 	}
 
 	/**

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -16,6 +16,13 @@ import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
+ * List of editor pending actions.
+ *
+ * Any asynchronous action that should be finished before the editor destroy (like file upload) should be registered
+ * in this plugin and removed after finish.
+ *
+ * This plugin listens to `window#beforeunload` event and displays browser prompt when a pending action is in progress.
+ *
  * @extends module:core/plugin~Plugin
  */
 export default class PendingActions extends Plugin {

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -33,7 +33,6 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * 		const pendingActions = editor.plugins.get( 'PendingActions' );
  * 		const action = pendingActions.add( 'Unsaved changes.' );
  *
- *
  * 		pendingActions.remove( action );
  *
  * Getting pending actions:

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -15,8 +15,6 @@ import DOMEmitterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
-//  This plugin is not able to interrupt actions or manage that in any other way.
-
 /**
  * List of editor pending actions.
  *
@@ -26,7 +24,29 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * All plugins, which register pending action provides also a message what action is ongoing
  * which can be displayed to a user and let him decide if he wants to interrupt the action or wait.
  *
- * This plugin listens to `window#beforeunload` event and displays browser prompt when a pending action is in progress.
+ * Adding and updating pending action:
+ *
+ * 		const pendingActions = editor.plugins.get( 'PendingActions' );
+ * 		const action = pendingActions.add( 'Upload in progress 0%' );
+ *
+ * 		action.message = 'Upload in progress 10%';
+ *
+ * Removing pending action:
+ *
+ * 		const pendingActions = editor.plugins.get( 'PendingActions' );
+ * 		const action = pendingActions.add( 'Unsaved changes.' );
+ *
+ *		pendingActions.remove( action );
+ *
+ * Getting pending actions:
+ *
+ * 		const pendingActions = editor.plugins.get( 'PendingActions' );
+ *
+ * 		const action1 = pendingActions.add( 'Action 1' );
+ * 		const action2 = pendingActions.add( 'Action 2' );
+ *
+ *		pendingActions.first // Returns action1
+ *		Array.from( pendingActions ) // Returns [ action1, action2 ]
  *
  * @extends module:core/plugin~Plugin
  */
@@ -67,12 +87,7 @@ export default class PendingActions extends Plugin {
 	 * This method returns an action object with observable message property.
 	 * The action object can be later used in the remove method. It also allows you to change the message.
 	 *
-	 *		const pendingActions = editor.plugins.get( 'PendingActions' );
-	 * 		const action = pendingActions.add( 'Upload in progress 0%' );
-	 *
-	 * 		action.message = 'Upload in progress 10%';
-	 *
-	 * @param {String} message
+	 * @param {String} message Action message.
 	 * @returns {Object} Observable object that represents a pending action.
 	 */
 	add( message ) {
@@ -106,14 +121,6 @@ export default class PendingActions extends Plugin {
 
 	/**
 	 * Returns first action from the list.
-	 *
-	 * 		const pendingActions = editor.plugins.get( 'PendingActions' );
-	 *
-	 * 		pendingActions.add( 'Action 1' );
-	 * 		pendingActions.add( 'Action 2' );
-	 *
-	 *		pendingActions.first // Returns 'Action 1'
-	 *		Array.from( pendingActions ) // Returns [ 'Action 1', 'Action 2' ]
 	 *
 	 * returns {Object} Pending action object.
 	 */

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -90,6 +90,11 @@ export default class PendingActions extends Plugin {
 	 */
 	add( message ) {
 		if ( typeof message !== 'string' ) {
+			/**
+			 * Message has to be a string.
+			 *
+			 * @error pendingactions-add-invalid-message
+			 */
 			throw new CKEditorError( 'pendingactions-add-invalid-message: Message has to be a string.' );
 		}
 

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -33,7 +33,8 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * 		const pendingActions = editor.plugins.get( 'PendingActions' );
  * 		const action = pendingActions.add( 'Unsaved changes.' );
  *
- *		pendingActions.remove( action );
+ *
+ * 		pendingActions.remove( action );
  *
  * Getting pending actions:
  *
@@ -42,8 +43,8 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  * 		const action1 = pendingActions.add( 'Action 1' );
  * 		const action2 = pendingActions.add( 'Action 2' );
  *
- *		pendingActions.first // Returns action1
- *		Array.from( pendingActions ) // Returns [ action1, action2 ]
+ * 		pendingActions.first // Returns action1
+ * 		Array.from( pendingActions ) // Returns [ action1, action2 ]
  *
  * @extends module:core/plugin~Plugin
  */

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -1,0 +1,85 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module core/pendingactions
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import Collection from '@ckeditor/ckeditor5-utils/src/collection';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+
+/**
+ * @extends module:core/plugin~Plugin
+ */
+export default class PendingActions extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'PendingActions';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		/**
+		 * Defines whether there is any registered pending action or not.
+		 *
+		 * @readonly
+		 * @observable
+		 * @type {Boolean} #isPending
+		 */
+		this.set( 'isPending', false );
+
+		/**
+		 * List of pending actions.
+		 *
+		 * @private
+		 * @type {module:utils/collection~Collection}
+		 */
+		this._actions = new Collection( { idProperty: '_id' } );
+	}
+
+	/**
+	 * Adds action to the list of pending actions.
+	 *
+	 * @param {String} message
+	 */
+	add( message ) {
+		if ( typeof message !== 'string' ) {
+			throw new CKEditorError( 'pendingactions-add-invalid-message: Message has to be a string.' );
+		}
+
+		const observable = Object.create( ObservableMixin );
+
+		observable.set( 'message', message );
+		this._actions.add( observable );
+		this.isPending = true;
+
+		return observable;
+	}
+
+	/**
+	 * Removes action from the list of pending actions.
+	 *
+	 * @param {Object} action Action object.
+	 */
+	remove( action ) {
+		this._actions.remove( action );
+		this.isPending = !!this._actions.length;
+	}
+
+	/**
+	 * Iterable interface.
+	 *
+	 * @returns {Iterable.<*>}
+	 */
+	[ Symbol.iterator ]() {
+		return this._actions[ Symbol.iterator ]();
+	}
+}

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -76,7 +76,10 @@ export default class PendingActions extends Plugin {
 	/**
 	 * Adds action to the list of pending actions.
 	 *
+	 * Methods returns an object with observable message property. Message can be changed.
+	 *
 	 * @param {String} message
+	 * @returns {Object} Observable object that represents a pending action.
 	 */
 	add( message ) {
 		if ( typeof message !== 'string' ) {

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -9,7 +9,7 @@
 
 /* global window */
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Plugin from './plugin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import DOMEmitterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -7,11 +7,8 @@
  * @module core/pendingactions
  */
 
-/* global window */
-
 import Plugin from './plugin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
-import DOMEmitterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -98,13 +98,13 @@ export default class PendingActions extends Plugin {
 			throw new CKEditorError( 'pendingactions-add-invalid-message: Message has to be a string.' );
 		}
 
-		const observable = Object.create( ObservableMixin );
+		const action = Object.create( ObservableMixin );
 
-		observable.set( 'message', message );
-		this._actions.add( observable );
+		action.set( 'message', message );
+		this._actions.add( action );
 		this.isPending = true;
 
-		return observable;
+		return action;
 	}
 
 	/**

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -41,21 +41,6 @@ export default class PendingActions extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	constructor( editor ) {
-		super( editor );
-
-		/**
-		 * DOM Emitter.
-		 *
-		 * @private
-		 * @type {module:utils/dom/emittermixin~EmitterMixin}
-		 */
-		this._domEmitter = Object.create( DOMEmitterMixin );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	init() {
 		/**
 		 * Defines whether there is any registered pending action or not.
@@ -74,15 +59,6 @@ export default class PendingActions extends Plugin {
 		 */
 		this._actions = new Collection( { idProperty: '_id' } );
 		this._actions.delegate( 'add', 'remove' ).to( this );
-
-		// It's not possible to easy test it because karma uses `beforeunload` event
-		// to warn before full page reload and this event cannot be dispatched manually.
-		/* istanbul ignore next */
-		this._domEmitter.listenTo( window, 'beforeunload', ( evtInfo, domEvt ) => {
-			if ( this.isPending ) {
-				domEvt.returnValue = this.first.message;
-			}
-		} );
 	}
 
 	/**
@@ -152,14 +128,6 @@ export default class PendingActions extends Plugin {
 	 */
 	[ Symbol.iterator ]() {
 		return this._actions[ Symbol.iterator ]();
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	destroy() {
-		super.destroy();
-		this._domEmitter.stopListening();
 	}
 
 	/**

--- a/src/pendingactions.js
+++ b/src/pendingactions.js
@@ -15,11 +15,16 @@ import DOMEmitterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
+//  This plugin is not able to interrupt actions or manage that in any other way.
+
 /**
  * List of editor pending actions.
  *
- * Any asynchronous action that should be finished before the editor destroy (like file upload) should be registered
- * in this plugin and removed after finish.
+ * This plugin should be used to synchronise plugins that execute long-lasting actions
+ * (i.e. file upload) with the editor integration. It gives a developer, who integrates the editor,
+ * an easy way to check if there are any pending action whenever such information is needed.
+ * All plugins, which register pending action provides also a message what action is ongoing
+ * which can be displayed to a user and let him decide if he wants to interrupt the action or wait.
  *
  * This plugin listens to `window#beforeunload` event and displays browser prompt when a pending action is in progress.
  *
@@ -83,7 +88,13 @@ export default class PendingActions extends Plugin {
 	/**
 	 * Adds action to the list of pending actions.
 	 *
-	 * Methods returns an object with observable message property. Message can be changed.
+	 * This method returns an action object with observable message property.
+	 * The action object can be later used in the remove method. It also allows you to change the message.
+	 *
+	 *		const pendingActions = editor.plugins.get( 'PendingActions' );
+	 * 		const action = pendingActions.add( 'Upload in progress 0%' );
+	 *
+	 * 		action.message = 'Upload in progress 10%';
 	 *
 	 * @param {String} message
 	 * @returns {Object} Observable object that represents a pending action.
@@ -119,6 +130,14 @@ export default class PendingActions extends Plugin {
 
 	/**
 	 * Returns first action from the list.
+	 *
+	 * 		const pendingActions = editor.plugins.get( 'PendingActions' );
+	 *
+	 * 		pendingActions.add( 'Action 1' );
+	 * 		pendingActions.add( 'Action 2' );
+	 *
+	 *		pendingActions.first // Returns 'Action 1'
+	 *		Array.from( pendingActions ) // Returns [ 'Action 1', 'Action 2' ]
 	 *
 	 * returns {Object} Pending action object.
 	 */

--- a/tests/manual/pendingactions.html
+++ b/tests/manual/pendingactions.html
@@ -1,6 +1,5 @@
 <div>
 	<button id="add-action">Add pending action</button>
-	<button id="add-action-progress">Add progressing pending action</button>
 </div>
 
 <h3>Pending actions list:</h3>

--- a/tests/manual/pendingactions.html
+++ b/tests/manual/pendingactions.html
@@ -1,0 +1,12 @@
+<div>
+	<button id="add-action">Add pending action</button>
+	<button id="add-action-progress">Add progressing pending action</button>
+</div>
+
+<h3>Pending actions list:</h3>
+<ol class="pending-actions"></ol>
+
+<div id="editor">
+	<h2>Heading 1</h2>
+	<p>Paragraph</p>
+</div>

--- a/tests/manual/pendingactions.js
+++ b/tests/manual/pendingactions.js
@@ -8,7 +8,7 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 
 import ArticlePluginSet from '../_utils/articlepluginset';
-import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
+import PendingActions from '../../src/pendingactions';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/tests/manual/pendingactions.js
+++ b/tests/manual/pendingactions.js
@@ -1,0 +1,80 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document, setTimeout */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+
+import ArticlePluginSet from '../_utils/articlepluginset';
+import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet, PendingActions ],
+		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ],
+		image: {
+			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ],
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+
+		const pendingActions = editor.plugins.get( PendingActions );
+		const actionsEl = document.querySelector( '.pending-actions' );
+
+		document.querySelector( '#add-action' ).addEventListener( 'click', () => {
+			const action = pendingActions.add( 'Static pending action.' );
+
+			wait( 5000 ).then( () => pendingActions.remove( action ) );
+		} );
+
+		document.querySelector( '#add-action-progress' ).addEventListener( 'click', () => {
+			const action = pendingActions.add( 'Dynamic pending action 0%.' );
+
+			wait( 1000 )
+				.then( () => ( action.message = 'Dynamic pending action 0%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => ( action.message = 'Dynamic pending action 20%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => ( action.message = 'Dynamic pending action 40%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => ( action.message = 'Dynamic pending action 60%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => ( action.message = 'Dynamic pending action 80%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => ( action.message = 'Dynamic pending action 1000%.' ) )
+				.then( () => wait( 500 ) )
+				.then( () => pendingActions.remove( action ) );
+		} );
+
+		pendingActions.on( 'add', () => displayActions() );
+		pendingActions.on( 'remove', () => displayActions() );
+
+		function displayActions() {
+			const frag = document.createDocumentFragment();
+
+			for ( const action of pendingActions ) {
+				const item = document.createElement( 'li' );
+
+				item.textContent = action.message;
+
+				action.on( 'change:message', () => {
+					item.textContent = action.message;
+				} );
+
+				frag.appendChild( item );
+			}
+
+			actionsEl.innerHTML = '';
+			actionsEl.appendChild( frag );
+		}
+
+		function wait( ms ) {
+			return new Promise( resolve => setTimeout( resolve, ms ) );
+		}
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/pendingactions.js
+++ b/tests/manual/pendingactions.js
@@ -25,26 +25,20 @@ ClassicEditor
 		const actionsEl = document.querySelector( '.pending-actions' );
 
 		document.querySelector( '#add-action' ).addEventListener( 'click', () => {
-			const action = pendingActions.add( 'Static pending action.' );
-
-			wait( 5000 ).then( () => pendingActions.remove( action ) );
-		} );
-
-		document.querySelector( '#add-action-progress' ).addEventListener( 'click', () => {
-			const action = pendingActions.add( 'Dynamic pending action 0%.' );
+			const action = pendingActions.add( 'Pending action 0%.' );
 
 			wait( 1000 )
-				.then( () => ( action.message = 'Dynamic pending action 0%.' ) )
+				.then( () => ( action.message = 'Pending action 0%.' ) )
 				.then( () => wait( 500 ) )
-				.then( () => ( action.message = 'Dynamic pending action 20%.' ) )
+				.then( () => ( action.message = 'Pending action 20%.' ) )
 				.then( () => wait( 500 ) )
-				.then( () => ( action.message = 'Dynamic pending action 40%.' ) )
+				.then( () => ( action.message = 'Pending action 40%.' ) )
 				.then( () => wait( 500 ) )
-				.then( () => ( action.message = 'Dynamic pending action 60%.' ) )
+				.then( () => ( action.message = 'Pending action 60%.' ) )
 				.then( () => wait( 500 ) )
-				.then( () => ( action.message = 'Dynamic pending action 80%.' ) )
+				.then( () => ( action.message = 'Pending action 80%.' ) )
 				.then( () => wait( 500 ) )
-				.then( () => ( action.message = 'Dynamic pending action 1000%.' ) )
+				.then( () => ( action.message = 'Pending action 100%.' ) )
 				.then( () => wait( 500 ) )
 				.then( () => pendingActions.remove( action ) );
 		} );

--- a/tests/manual/pendingactions.js
+++ b/tests/manual/pendingactions.js
@@ -43,6 +43,12 @@ ClassicEditor
 				.then( () => pendingActions.remove( action ) );
 		} );
 
+		window.addEventListener( 'beforeunload', evt => {
+			if ( pendingActions.isPending ) {
+				evt.returnValue = pendingActions.first.message;
+			}
+		} );
+
 		pendingActions.on( 'add', () => displayActions() );
 		pendingActions.on( 'remove', () => displayActions() );
 

--- a/tests/manual/pendingactions.md
+++ b/tests/manual/pendingactions.md
@@ -1,8 +1,6 @@
 ## Pending actions
 
-1. Click `Add pending action`
-2. Check if action is displayed as an item of Pending Actions list (action should disappear after 5 seconds)
-3. Click `Add progressing pending actions`
-4. Check if action message changes (action should disappear when progress reaches 100%)
-5. Try to reload page or close the browser tab when pending action is displayed, you should see a prompt
-6. Try to reload page when there are no pending actions, you shouldn't see a prompt
+1. Click `Add pending actions`
+2. Check if action message is changing (action should disappear when progress reaches 100%)
+3. Try to reload page or close the browser tab when pending action is displayed, you should see a prompt
+4. Try to reload page when there are no pending actions, you shouldn't see a prompt

--- a/tests/manual/pendingactions.md
+++ b/tests/manual/pendingactions.md
@@ -1,0 +1,8 @@
+## Pending actions
+
+1. Click `Add pending action`
+2. Check if action is displayed as an item of Pending Actions list (action should disappear after 5 seconds)
+3. Click `Add progressing pending actions`
+4. Check if action message changes (action should disappear when progress reaches 100%)
+5. Try to reload page or close the browser tab when pending action is displayed, you should see a prompt
+6. Try to reload page when there are no pending actions, you shouldn't see a prompt

--- a/tests/pendingactions.js
+++ b/tests/pendingactions.js
@@ -114,6 +114,16 @@ describe( 'PendingActions', () => {
 		} );
 	} );
 
+	describe( 'first', () => {
+		it( 'should return first pending action from the list', () => {
+			const action = pendingActions.add( 'Action 1' );
+
+			pendingActions.add( 'Action 2' );
+
+			expect( pendingActions.first ).to.equal( action );
+		} );
+	} );
+
 	describe( 'iterator', () => {
 		it( 'should return all panding actions', () => {
 			pendingActions.add( 'Action 1' );

--- a/tests/pendingactions.js
+++ b/tests/pendingactions.js
@@ -1,0 +1,103 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import VirtaulTestEditor from './_utils/virtualtesteditor';
+import PendingActions from '../src/pendingactions';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+
+let editor, pendingActions;
+
+beforeEach( () => {
+	return VirtaulTestEditor.create( {
+		plugins: [ PendingActions ],
+	} ).then( newEditor => {
+		editor = newEditor;
+		pendingActions = editor.plugins.get( PendingActions );
+	} );
+} );
+
+afterEach( () => {
+	return editor.destroy();
+} );
+
+describe( 'PendingActions', () => {
+	it( 'should define static pluginName property', () => {
+		expect( PendingActions ).to.have.property( 'pluginName', 'PendingActions' );
+	} );
+
+	describe( 'init()', () => {
+		it( 'should have isPending observable', () => {
+			const spy = sinon.spy();
+
+			pendingActions.on( 'change:isPending', spy );
+
+			expect( pendingActions ).to.have.property( 'isPending', false );
+
+			pendingActions.isPending = true;
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
+	describe( 'add()', () => {
+		it( 'should register and return pending action', () => {
+			const action = pendingActions.add( 'Action' );
+
+			expect( action ).be.an( 'object' );
+			expect( action.message ).to.equal( 'Action' );
+		} );
+
+		it( 'should return observable', () => {
+			const spy = sinon.spy();
+			const action = pendingActions.add( 'Action' );
+
+			action.on( 'change:message', spy );
+
+			action.message = 'New message';
+
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should update isPending observable', () => {
+			expect( pendingActions ).to.have.property( 'isPending', false );
+
+			pendingActions.add( 'Action' );
+
+			expect( pendingActions ).to.have.property( 'isPending', true );
+		} );
+
+		it( 'should throw an error when invalid message is given', () => {
+			expect( () => {
+				pendingActions.add( {} );
+			} ).to.throw( CKEditorError, /^pendingactions-add-invalid-message/ );
+		} );
+	} );
+
+	describe( 'remove()', () => {
+		it( 'should remove given pending action and update observable', () => {
+			const action1 = pendingActions.add( 'Action 1' );
+			const action2 = pendingActions.add( 'Action 2' );
+
+			expect( pendingActions ).to.have.property( 'isPending', true );
+
+			pendingActions.remove( action1 );
+
+			expect( pendingActions ).to.have.property( 'isPending', true );
+
+			pendingActions.remove( action2 );
+
+			expect( pendingActions ).to.have.property( 'isPending', false );
+		} );
+	} );
+
+	describe( 'iterator', () => {
+		it( 'should return all panding actions', () => {
+			pendingActions.add( 'Action 1' );
+			pendingActions.add( 'Action 2' );
+
+			expect( Array.from( pendingActions, action => action.message ) ).to.have.members( [ 'Action 1', 'Action 2' ] );
+		} );
+	} );
+} );

--- a/tests/pendingactions.js
+++ b/tests/pendingactions.js
@@ -73,6 +73,16 @@ describe( 'PendingActions', () => {
 				pendingActions.add( {} );
 			} ).to.throw( CKEditorError, /^pendingactions-add-invalid-message/ );
 		} );
+
+		it( 'should fire add event with added item', () => {
+			const spy = sinon.spy();
+
+			pendingActions.on( 'add', spy );
+
+			const action = pendingActions.add( 'Some action' );
+
+			sinon.assert.calledWith( spy, sinon.match.any, action );
+		} );
 	} );
 
 	describe( 'remove()', () => {
@@ -89,6 +99,18 @@ describe( 'PendingActions', () => {
 			pendingActions.remove( action2 );
 
 			expect( pendingActions ).to.have.property( 'isPending', false );
+		} );
+
+		it( 'should fire remove event with removed item', () => {
+			const spy = sinon.spy();
+
+			pendingActions.on( 'remove', spy );
+
+			const action = pendingActions.add( 'Some action' );
+
+			pendingActions.remove( action );
+
+			sinon.assert.calledWith( spy, sinon.match.any, action );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced PendingActions plugin. Closes ckeditor/ckeditor5#2934.

---

This is a very basic implementation that covers all current needs.

It is possible to add pending action with a custom message and change this message. Message is observable.

Besides plugin listens to `window#beforeunload` event and displays prompt in a case of pending action.

```javascript
const action = this.editor.plugins.get( 'PendingActions' ).add( 'Custom message' );

action.message = 'New message';

this.editor.plugins.get( 'PendingActions' ).remove( action );
```