### PR TITLE
Internal: Used `beforeChange` instead of `change` to force command read-only mode.

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -79,19 +79,13 @@ export default class Command {
 		// By default commands are disabled when the editor is in read-only mode.
 		this.listenTo( editor, 'change:isReadOnly', ( evt, name, value ) => {
 			if ( value ) {
-				// See a ticket about overriding observable properties
-				// https://github.com/ckeditor/ckeditor5-utils/issues/171.
-				this.on( 'change:isEnabled', forceDisable, { priority: 'lowest' } );
+				this.on( 'beforeChange:isEnabled', forceDisable, { priority: 'highest' } );
 				this.isEnabled = false;
 			} else {
-				this.off( 'change:isEnabled', forceDisable );
+				this.off( 'beforeChange:isEnabled', forceDisable );
 				this.refresh();
 			}
 		} );
-
-		function forceDisable() {
-			this.isEnabled = false;
-		}
 	}
 
 	/**
@@ -139,3 +133,9 @@ export default class Command {
 }
 
 mix( Command, ObservableMixin );
+
+// Helper function that forces command to be disabled.
+function forceDisable( evt ) {
+	evt.return = false;
+	evt.stop();
+}

--- a/tests/command.js
+++ b/tests/command.js
@@ -98,6 +98,22 @@ describe( 'Command', () => {
 
 			expect( editor.something ).to.false;
 		} );
+
+		it( 'stops beforeChange event to force disabled and not affect change event', () => {
+			const beforeChangeSpy = sinon.spy();
+			const changeSpy = sinon.spy();
+
+			command.isEnabled = true;
+			editor.isReadOnly = false;
+
+			command.on( 'beforeChange', beforeChangeSpy );
+			command.on( 'change', changeSpy );
+
+			editor.isReadOnly = true;
+
+			sinon.assert.notCalled( beforeChangeSpy );
+			sinon.assert.calledOnce( changeSpy );
+		} );
 	} );
 
 	describe( 'execute()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used `beforeChange` instead of `change` to force `Command` read-only mode. Closes https://github.com/ckeditor/ckeditor5-utils/issues/171.

---

### Requires
- https://github.com/ckeditor/ckeditor5-utils/pull/241
