### PR TITLE
Editor#destroy waits for the initialization

### DIFF
--- a/tests/_utils-tests/modeltesteditor.js
+++ b/tests/_utils-tests/modeltesteditor.js
@@ -29,12 +29,14 @@ describe( 'ModelTestEditor', () => {
 
 		it( 'should disable editing pipeline', () => {
 			const spy = sinon.spy( EditingController.prototype, 'destroy' );
-			const editor = new ModelTestEditor( { foo: 1 } );
 
-			sinon.assert.calledOnce( spy );
+			return ModelTestEditor.create( { foo: 1 } ).then( editor => {
+				sinon.assert.calledOnce( spy );
 
-			spy.restore();
-			return editor.destroy();
+				spy.restore();
+
+				return editor.destroy();
+			} );
 		} );
 
 		it( 'creates main root element', () => {

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -197,10 +197,10 @@ describe( 'Editor', () => {
 		} );
 
 		it( 'is `destroyed` after editor destroy', () => {
-			const editor = new Editor();
-
-			return editor.destroy().then( () => {
-				expect( editor.state ).to.equal( 'destroyed' );
+			return Editor.create().then( editor => {
+				return editor.destroy().then( () => {
+					expect( editor.state ).to.equal( 'destroyed' );
+				} );
 			} );
 		} );
 
@@ -283,33 +283,49 @@ describe( 'Editor', () => {
 
 	describe( 'destroy()', () => {
 		it( 'should fire "destroy"', () => {
-			const editor = new Editor();
-			const spy = sinon.spy();
+			return Editor.create().then( editor => {
+				const spy = sinon.spy();
 
-			editor.on( 'destroy', spy );
+				editor.on( 'destroy', spy );
 
-			return editor.destroy().then( () => {
-				expect( spy.calledOnce ).to.be.true;
+				return editor.destroy().then( () => {
+					expect( spy.calledOnce ).to.be.true;
+				} );
 			} );
 		} );
 
 		it( 'should destroy all components it initialized', () => {
+			return Editor.create().then( editor => {
+				const dataDestroySpy = sinon.spy( editor.data, 'destroy' );
+				const modelDestroySpy = sinon.spy( editor.model, 'destroy' );
+				const editingDestroySpy = sinon.spy( editor.editing, 'destroy' );
+				const pluginsDestroySpy = sinon.spy( editor.plugins, 'destroy' );
+				const keystrokesDestroySpy = sinon.spy( editor.keystrokes, 'destroy' );
+
+				return editor.destroy()
+					.then( () => {
+						sinon.assert.calledOnce( dataDestroySpy );
+						sinon.assert.calledOnce( modelDestroySpy );
+						sinon.assert.calledOnce( editingDestroySpy );
+						sinon.assert.calledOnce( pluginsDestroySpy );
+						sinon.assert.calledOnce( keystrokesDestroySpy );
+					} );
+			} );
+		} );
+
+		it( 'should wait for the full init before destroying', done => {
+			const spy = sinon.spy();
 			const editor = new Editor();
 
-			const dataDestroySpy = sinon.spy( editor.data, 'destroy' );
-			const modelDestroySpy = sinon.spy( editor.model, 'destroy' );
-			const editingDestroySpy = sinon.spy( editor.editing, 'destroy' );
-			const pluginsDestroySpy = sinon.spy( editor.plugins, 'destroy' );
-			const keystrokesDestroySpy = sinon.spy( editor.keystrokes, 'destroy' );
+			editor.on( 'destroy', () => {
+				done();
+			} );
 
-			return editor.destroy()
-				.then( () => {
-					sinon.assert.calledOnce( dataDestroySpy );
-					sinon.assert.calledOnce( modelDestroySpy );
-					sinon.assert.calledOnce( editingDestroySpy );
-					sinon.assert.calledOnce( pluginsDestroySpy );
-					sinon.assert.calledOnce( keystrokesDestroySpy );
-				} );
+			editor.destroy();
+
+			sinon.assert.notCalled( spy );
+
+			editor.fire( 'ready' );
 		} );
 	} );
 

--- a/tests/editor/utils/attachtoform.js
+++ b/tests/editor/utils/attachtoform.js
@@ -34,6 +34,7 @@ describe( 'attachToForm()', () => {
 		editor.data.processor = new HtmlDataProcessor();
 		editor.model.document.createRoot();
 		editor.model.schema.extend( '$text', { allowIn: '$root' } );
+		editor.fire( 'ready' );
 
 		editor.data.set( 'foo bar' );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `Editor#destroy` waits for the initialization. Closes ckeditor/ckeditor5#2891.

---

### Requires
- https://github.com/ckeditor/ckeditor5-editor-decoupled/tree/t/ckeditor5-core/134
- https://github.com/ckeditor/ckeditor5-undo/tree/t/ckeditor5-core/134