### PR TITLE
Replace `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-engine": "^10.2.0",
-    "@ckeditor/ckeditor5-utils": "^10.2.0"
+    "@ckeditor/ckeditor5-utils": "^10.2.0",
+    "lodash-es": "^4.17.10"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-autoformat": "^10.0.2",

--- a/src/editor/utils/attachtoform.js
+++ b/src/editor/utils/attachtoform.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import isFunction from '@ckeditor/ckeditor5-utils/src/lib/lodash/isFunction';
+import { isFunction } from 'lodash-es';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Replaced `ckeditor5-uitls/src/lib/lodash` imports with `lodash-es`.

---

### Additional information

Part of the https://github.com/ckeditor/ckeditor5-utils/pull/252.
