### PR TITLE
t/146: Implemented the `extraPlugins` editor configuration

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -232,8 +232,9 @@ export default class Editor {
 		function loadPlugins() {
 			const plugins = config.get( 'plugins' ) || [];
 			const removePlugins = config.get( 'removePlugins' ) || [];
+			const extraPlugins = config.get( 'extraPlugins' ) || [];
 
-			return that.plugins.load( plugins, removePlugins );
+			return that.plugins.load( plugins.concat( extraPlugins ), removePlugins );
 		}
 
 		function initPlugins( loadedPlugins, method ) {

--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -57,7 +57,27 @@
  *			plugins: [ Essentials, Bold ]
  *		};
  *
+ * **Note:** To load additional plugins, you should use the {@link #extraPlugins `extraPlugins`} configuration.
+ * To narrow the list of loaded plugins, use the {@link #removePlugins `removePlugins`} configuration.
+ *
  * @member {Array.<String|Function>} module:core/editor/editorconfig~EditorConfig#plugins
+ */
+
+/**
+ * The list of additional plugins to load along those already available in the
+ * {@glink builds/guides/overview editor build}. It extends the {@link #plugins `plugins`} configuration.
+ *
+ *		import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
+ *		import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+ *
+ *		const config = {
+ *			extraPlugins: [ Highlight, Underline ]
+ *		};
+ *
+ * **Note:** Make sure you include the new features in you toolbar configuration. Learn more
+ * about {@glink builds/guides/integration/configuration#toolbar-setup toolbar setup}.
+ *
+ * @member {Array.<Function>} module:core/editor/editorconfig~EditorConfig#extraPlugins
  */
 
 /**

--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -67,12 +67,17 @@
  * The list of additional plugins to load along those already available in the
  * {@glink builds/guides/overview editor build}. It extends the {@link #plugins `plugins`} configuration.
  *
- *		import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
- *		import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+ *		function MyPlugin( editor ) {
+ *			// ...
+ *		}
  *
  *		const config = {
- *			extraPlugins: [ Highlight, Underline ]
+ *			extraPlugins: [ MyPlugin ]
  *		};
+ *
+ * **Note:** This configuration works only for simple plugins which utilize the
+ * {@link module:core/plugin~PluginInterface plugin interface} and have no dependencies. To extend a
+ * build with complex features, create a {@glink builds/guides/development/custom-builds custom build}.
  *
  * **Note:** Make sure you include the new features in you toolbar configuration. Learn more
  * about {@glink builds/guides/integration/configuration#toolbar-setup toolbar setup}.

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -630,47 +630,107 @@ describe( 'Editor', () => {
 				} );
 		} );
 
-		it( 'should not load plugins specified in the config as "removePlugins"', () => {
-			const editor = new Editor( {
-				plugins: [ PluginA, PluginD ],
-				removePlugins: [ PluginD ]
+		describe( '"removePlugins" config', () => {
+			it( 'should prevent plugins from being loaded', () => {
+				const editor = new Editor( {
+					plugins: [ PluginA, PluginD ],
+					removePlugins: [ PluginD ]
+				} );
+
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 1 );
+						expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					} );
 			} );
 
-			return editor.initPlugins()
-				.then( () => {
-					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+			it( 'should not load plugins built in the Editor', () => {
+				Editor.builtinPlugins = [ PluginA, PluginD ];
+
+				const editor = new Editor( {
+					removePlugins: [ 'D' ]
 				} );
+
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 1 );
+						expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+					} );
+			} );
+
+			it( 'should not load plugins build into Editor\'s subclass', () => {
+				class CustomEditor extends Editor {}
+
+				CustomEditor.builtinPlugins = [ PluginA, PluginD ];
+
+				const editor = new CustomEditor( {
+					removePlugins: [ 'D' ]
+				} );
+
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 1 );
+						expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+					} );
+			} );
 		} );
 
-		it( 'should not load plugins built in the Editor when "removePlugins" option is specified', () => {
-			Editor.builtinPlugins = [ PluginA, PluginD ];
+		describe( '"extraPlugins" config', () => {
+			it( 'should load additional plugins', () => {
+				const editor = new Editor( {
+					plugins: [ PluginA, PluginC ],
+					extraPlugins: [ PluginB ]
+				} );
 
-			const editor = new Editor( {
-				removePlugins: [ 'D' ]
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 3 );
+						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+					} );
 			} );
 
-			return editor.initPlugins()
-				.then( () => {
-					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+			it( 'should not duplicate plugins', () => {
+				const editor = new Editor( {
+					plugins: [ PluginA, PluginB ],
+					extraPlugins: [ PluginB ]
 				} );
-		} );
 
-		it( 'should not load plugins build into Editor\'s subclass when "removePlugins" option is specified', () => {
-			class CustomEditor extends Editor {}
-
-			CustomEditor.builtinPlugins = [ PluginA, PluginD ];
-
-			const editor = new CustomEditor( {
-				removePlugins: [ 'D' ]
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 2 );
+						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+					} );
 			} );
 
-			return editor.initPlugins()
-				.then( () => {
-					expect( getPlugins( editor ).length ).to.equal( 1 );
-					expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+			it( 'should not duplicate plugins built in the Editor', () => {
+				Editor.builtinPlugins = [ PluginA, PluginB ];
+
+				const editor = new Editor( {
+					extraPlugins: [ 'B' ]
 				} );
+
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 2 );
+						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+					} );
+			} );
+
+			it( 'should not duplicate plugins build into Editor\'s subclass', () => {
+				class CustomEditor extends Editor {}
+
+				CustomEditor.builtinPlugins = [ PluginA, PluginB ];
+
+				const editor = new CustomEditor( {
+					extraPlugins: [ 'B' ]
+				} );
+
+				return editor.initPlugins()
+					.then( () => {
+						expect( getPlugins( editor ).length ).to.equal( 2 );
+						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+					} );
+			} );
 		} );
 
 		it( 'should not call "afterInit" method if plugin does not have this method', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented the `extraPlugins` editor configuration. Closes ckeditor/ckeditor5#2895.

---

### Docs dilema

At first, I wanted to mention the new config in the [configuration guide](https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/builds/guides/integration/configuration.html#adding-features) but it already has a section about adding features which says

> As CKEditor builds do not include all possible features, the only way to add more features to them is to create a custom build.

So I figured it's more a custom–build–approach config, but [the guide](https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/builds/guides/development/custom-builds.html) is `builtinPlugins`–oriented and the new section would not make sense either.

It's the same with the [migration guide](https://ckeditor5.github.io/docs/nightly/ckeditor5/latest/builds/guides/migrate.html#configuration-options-compatibility-table). 

> extraPlugins | Enabling extra plugins is possible by creating a custom build.

How should I document the new option then?