### PR TITLE
T/148:  Throw error ind editor.plugins.get() when plugin is not loaded

### DIFF
--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -72,7 +72,18 @@ export default class PluginCollection {
 	/**
 	 * Gets the plugin instance by its constructor or name.
 	 *
-	 * **Note**: This method will throw error if plugin is not loaded. Use {@link #has} to check if plugin is available.
+	 *		// Check if 'Clipboard' plugin was loaded.
+	 *		if ( editor.plugins.has( 'Clipboard' ) ) {
+	 *			// Get clipboard plugin instance
+	 *			const clipboard = editor.plugins.get( 'Clipboard' );
+	 *
+	 *			this.listenTo( clipboard, 'inputTransformation', ( evt, data ) => {
+	 *				// Do something on clipboard input.
+	 *			} );
+	 *		}
+	 *
+	 * **Note**: This method will throw error if plugin is not loaded. Use `{@link #has editor.plugins.has()}`
+	 * to check if plugin is available.
 	 *
 	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
 	 * @returns {module:core/plugin~PluginInterface}
@@ -88,6 +99,9 @@ export default class PluginCollection {
 			 * the plugin collection.
 			 * This is usually done in CKEditor 5 builds by setting the {@link module:core/editor/editor~Editor.builtinPlugins}
 			 * property.
+			 *
+			 * **Note**: You can use `{@link module:core/plugincollection~PluginCollection#has editor.plugins.has()}`
+			 * to check if plugin was loaded.
 			 *
 			 * @error plugincollection-plugin-not-loaded
 			 * @param {String} plugin The name of the plugin which is not loaded.
@@ -108,6 +122,14 @@ export default class PluginCollection {
 
 	/**
 	 * Checks if plugin is loaded.
+	 *
+	 *		// Check if 'Clipboard' plugin was loaded.
+	 *		if ( editor.plugins.has( 'Clipboard' ) ) {
+	 *			// Now use clipboard plugin instance:
+	 *			const clipboard = editor.plugins.get( 'Clipboard' );
+	 *
+	 *			// ...
+	 *		}
 	 *
 	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
 	 * @returns {Boolean}

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -72,6 +72,8 @@ export default class PluginCollection {
 	/**
 	 * Gets the plugin instance by its constructor or name.
 	 *
+	 * **Note**: This method will throw error if plugin is not loaded. Use {@link #has} to check if plugin is available.
+	 *
 	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
 	 * @returns {module:core/plugin~PluginInterface}
 	 */
@@ -102,6 +104,16 @@ export default class PluginCollection {
 		}
 
 		return plugin;
+	}
+
+	/**
+	 * Checks if plugin is loaded.
+	 *
+	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
+	 * @returns {Boolean}
+	 */
+	has( key ) {
+		return this._plugins.has( key );
 	}
 
 	/**

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -140,7 +140,7 @@ export default class PluginCollection {
 			}
 
 			// The plugin is already loaded or being loaded - do nothing.
-			if ( that.get( PluginConstructor ) || loading.has( PluginConstructor ) ) {
+			if ( that._plugins.has( PluginConstructor ) || loading.has( PluginConstructor ) ) {
 				return;
 			}
 

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -76,7 +76,32 @@ export default class PluginCollection {
 	 * @returns {module:core/plugin~PluginInterface}
 	 */
 	get( key ) {
-		return this._plugins.get( key );
+		const plugin = this._plugins.get( key );
+
+		if ( !plugin ) {
+			/**
+			 * The plugin is not loaded and could not be obtained.
+			 *
+			 * Plugin classes (constructors) need to be provided to the editor and must be loaded before they can be obtained from
+			 * the plugin collection.
+			 * This is usually done in CKEditor 5 builds by setting the {@link module:core/editor/editor~Editor.builtinPlugins}
+			 * property.
+			 *
+			 * @error plugincollection-plugin-not-loaded
+			 * @param {String} plugin The name of the plugin which is not loaded.
+			 */
+			const warnMessage = 'plugincollection-plugin-not-loaded: The requested plugin is not loaded.';
+
+			let pluginName = key;
+
+			if ( typeof key == 'function' ) {
+				pluginName = key.pluginName || key.name;
+			}
+
+			log.warn( warnMessage, { plugin: pluginName } );
+		}
+
+		return plugin;
 	}
 
 	/**

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -90,7 +90,7 @@ export default class PluginCollection {
 			 * @error plugincollection-plugin-not-loaded
 			 * @param {String} plugin The name of the plugin which is not loaded.
 			 */
-			const warnMessage = 'plugincollection-plugin-not-loaded: The requested plugin is not loaded.';
+			const errorMsg = 'plugincollection-plugin-not-loaded: The requested plugin is not loaded.';
 
 			let pluginName = key;
 
@@ -98,7 +98,7 @@ export default class PluginCollection {
 				pluginName = key.pluginName || key.name;
 			}
 
-			log.warn( warnMessage, { plugin: pluginName } );
+			throw new CKEditorError( errorMsg, { plugin: pluginName } );
 		}
 
 		return plugin;

--- a/tests/pendingactions.js
+++ b/tests/pendingactions.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import VirtaulTestEditor from './_utils/virtualtesteditor';
+import VirtualTestEditor from './_utils/virtualtesteditor';
 import PendingActions from '../src/pendingactions';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
@@ -11,7 +11,7 @@ let editor, pendingActions;
 
 describe( 'PendingActions', () => {
 	beforeEach( () => {
-		return VirtaulTestEditor.create( {
+		return VirtualTestEditor.create( {
 			plugins: [ PendingActions ],
 		} ).then( newEditor => {
 			editor = newEditor;

--- a/tests/pendingactions.js
+++ b/tests/pendingactions.js
@@ -9,20 +9,20 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 let editor, pendingActions;
 
-beforeEach( () => {
-	return VirtaulTestEditor.create( {
-		plugins: [ PendingActions ],
-	} ).then( newEditor => {
-		editor = newEditor;
-		pendingActions = editor.plugins.get( PendingActions );
-	} );
-} );
-
-afterEach( () => {
-	return editor.destroy();
-} );
-
 describe( 'PendingActions', () => {
+	beforeEach( () => {
+		return VirtaulTestEditor.create( {
+			plugins: [ PendingActions ],
+		} ).then( newEditor => {
+			editor = newEditor;
+			pendingActions = editor.plugins.get( PendingActions );
+		} );
+	} );
+
+	afterEach( () => {
+		return editor.destroy();
+	} );
+
 	it( 'should define static pluginName property', () => {
 		expect( PendingActions ).to.have.property( 'pluginName', 'PendingActions' );
 	} );

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -485,6 +485,37 @@ describe( 'PluginCollection', () => {
 		} );
 	} );
 
+	describe( 'has()', () => {
+		let plugins;
+
+		beforeEach( () => {
+			plugins = new PluginCollection( editor, availablePlugins );
+		} );
+
+		it( 'returns false if plugins is not loaded (retrieved by name)', () => {
+			expect( plugins.has( 'foobar' ) ).to.be.false;
+		} );
+
+		it( 'returns false if plugins is not loaded (retrieved by class)', () => {
+			class SomePlugin extends Plugin {
+			}
+
+			expect( plugins.has( SomePlugin ) ).to.be.false;
+		} );
+
+		it( 'returns true if plugins is loaded (retrieved by name)', () => {
+			return plugins.load( [ PluginA ] ).then( () => {
+				expect( plugins.has( 'A' ) ).to.be.true;
+			} );
+		} );
+
+		it( 'returns true if plugins is loaded (retrieved by class)', () => {
+			return plugins.load( [ PluginA ] ).then( () => {
+				expect( plugins.has( PluginA ) ).to.be.true;
+			} );
+		} );
+	} );
+
 	describe( 'destroy()', () => {
 		it( 'calls Plugin#destroy() method on every loaded plugin', () => {
 			let destroySpyForPluginA, destroySpyForPluginB;

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -448,6 +448,59 @@ describe( 'PluginCollection', () => {
 					expect( plugins.get( SomePlugin ) ).to.be.instanceOf( SomePlugin );
 				} );
 		} );
+
+		it( 'warns if plugin cannot be retrieved by name', () => {
+			const logSpy = testUtils.sinon.stub( log, 'warn' );
+
+			const plugins = new PluginCollection( editor, availablePlugins );
+
+			return plugins.load( [] ).then( () => {
+				const plugin = plugins.get( 'foo' );
+
+				expect( plugin ).to.be.undefined;
+
+				expect( logSpy.calledOnce ).to.equal( true );
+				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
+				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'foo' } );
+			} );
+		} );
+
+		it( 'warns if plugin cannot be retrieved by class', () => {
+			class SomePlugin extends Plugin {}
+			SomePlugin.pluginName = 'foo';
+
+			const logSpy = testUtils.sinon.stub( log, 'warn' );
+
+			const plugins = new PluginCollection( editor, availablePlugins );
+
+			return plugins.load( [] ).then( () => {
+				const plugin = plugins.get( SomePlugin );
+
+				expect( plugin ).to.be.undefined;
+
+				expect( logSpy.calledOnce ).to.equal( true );
+				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
+				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'foo' } );
+			} );
+		} );
+
+		it( 'logs function (class) name if plugin cannot be retrieved by class', () => {
+			class SomePlugin extends Plugin {}
+
+			const logSpy = testUtils.sinon.stub( log, 'warn' );
+
+			const plugins = new PluginCollection( editor, availablePlugins );
+
+			return plugins.load( [] ).then( () => {
+				const plugin = plugins.get( SomePlugin );
+
+				expect( plugin ).to.be.undefined;
+
+				expect( logSpy.calledOnce ).to.equal( true );
+				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
+				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'SomePlugin' } );
+			} );
+		} );
 	} );
 
 	describe( 'destroy()', () => {

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -449,56 +449,38 @@ describe( 'PluginCollection', () => {
 				} );
 		} );
 
-		it( 'warns if plugin cannot be retrieved by name', () => {
-			const logSpy = testUtils.sinon.stub( log, 'warn' );
-
+		it( 'throws if plugin cannot be retrieved by name', () => {
 			const plugins = new PluginCollection( editor, availablePlugins );
 
 			return plugins.load( [] ).then( () => {
-				const plugin = plugins.get( 'foo' );
-
-				expect( plugin ).to.be.undefined;
-
-				expect( logSpy.calledOnce ).to.equal( true );
-				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
-				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'foo' } );
+				expect( () => plugins.get( 'foo' ) )
+					.to.throw( CKEditorError, /^plugincollection-plugin-not-loaded:/ )
+					.with.deep.property( 'data', { plugin: 'foo' } );
 			} );
 		} );
 
-		it( 'warns if plugin cannot be retrieved by class', () => {
+		it( 'throws if plugin cannot be retrieved by class', () => {
 			class SomePlugin extends Plugin {}
 			SomePlugin.pluginName = 'foo';
 
-			const logSpy = testUtils.sinon.stub( log, 'warn' );
-
 			const plugins = new PluginCollection( editor, availablePlugins );
 
 			return plugins.load( [] ).then( () => {
-				const plugin = plugins.get( SomePlugin );
-
-				expect( plugin ).to.be.undefined;
-
-				expect( logSpy.calledOnce ).to.equal( true );
-				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
-				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'foo' } );
+				expect( () => plugins.get( SomePlugin ) )
+					.to.throw( CKEditorError, /^plugincollection-plugin-not-loaded:/ )
+					.with.deep.property( 'data', { plugin: 'foo' } );
 			} );
 		} );
 
-		it( 'logs function (class) name if plugin cannot be retrieved by class', () => {
+		it( 'throws if plugin cannot be retrieved by class (class name in error)', () => {
 			class SomePlugin extends Plugin {}
-
-			const logSpy = testUtils.sinon.stub( log, 'warn' );
 
 			const plugins = new PluginCollection( editor, availablePlugins );
 
 			return plugins.load( [] ).then( () => {
-				const plugin = plugins.get( SomePlugin );
-
-				expect( plugin ).to.be.undefined;
-
-				expect( logSpy.calledOnce ).to.equal( true );
-				expect( logSpy.firstCall.args[ 0 ] ).to.match( /^plugincollection-plugin-not-loaded:/ );
-				expect( logSpy.firstCall.args[ 1 ] ).to.deep.equal( { plugin: 'SomePlugin' } );
+				expect( () => plugins.get( SomePlugin ) )
+					.to.throw( CKEditorError, /^plugincollection-plugin-not-loaded:/ )
+					.with.deep.property( 'data', { plugin: 'SomePlugin' } );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Throw error ind editor.plugins.get() when plugin is not loaded. Closes ckeditor/ckeditor5#2899.

BREAKING CHANGE: The `editor.plugins.get()` will now throw error if plugin is not loaded. Use `editor.plugins.has()` to check if plugin is available.

---

### Additional information

* As discussed: the `requires() -> [ 'String' ]` already is supported.
* I've added the error to the `editor.plugins.get()` call.
* Other repos that have been update are gathered in [ckeditor5 branch](https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-core/148):
    - ckfinder: https://github.com/ckeditor/ckeditor5-ckfinder/pull/34
    - image: https://github.com/ckeditor/ckeditor5-image/pull/260
    - table: https://github.com/ckeditor/ckeditor5-table/pull/156
    - widget: https://github.com/ckeditor/ckeditor5-widget/pull/63
