### PR TITLE
Memory leaks fix, part I: create/destroy

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -278,15 +278,6 @@ export default class Editor {
 				this.data.destroy();
 				this.editing.destroy();
 				this.keystrokes.destroy();
-
-				// Fail-safe dereference of entities that may hold back reference to the editor - prevent memory leaks #1341
-				this.plugins = null;
-				this.commands = null;
-				this.model = null;
-				this.data = null;
-				this.editing = null;
-				this.keystrokes = null;
-				this.conversion = null;
 			} );
 	}
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -278,6 +278,15 @@ export default class Editor {
 				this.data.destroy();
 				this.editing.destroy();
 				this.keystrokes.destroy();
+
+				// Fail-safe dereference of entities that may hold back reference to the editor - prevent memory leaks #1341
+				this.plugins = null;
+				this.commands = null;
+				this.model = null;
+				this.data = null;
+				this.editing = null;
+				this.keystrokes = null;
+				this.conversion = null;
 			} );
 	}
 

--- a/src/editor/editorui.js
+++ b/src/editor/editorui.js
@@ -80,6 +80,7 @@ export default class EditorUI {
 	destroy() {
 		this.stopListening();
 		this.view.destroy();
+		this.focusTracker.destroy();
 	}
 
 	/**

--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -1,0 +1,144 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global window, document, setTimeout */
+
+const MiB = 1024 * 1024;
+
+/**
+ * @param {Function} callback Callback with test suit body
+ */
+export function describeMemoryUsage( callback ) {
+	describe( 'memory usage', () => {
+		skipIfNoGarbageCollector();
+
+		beforeEach( () => collectGarbageAndWait() );
+
+		beforeEach( createEditorElement );
+
+		afterEach( destroyEditorElement );
+
+		callback();
+	} );
+}
+
+/**
+ * @param {String} testName
+ * @param {Function} editorCreator Callback which creates editor and returns it's `.create()` promise.
+ */
+export function testMemoryUsage( testName, editorCreator ) {
+	it( testName, function() {
+		// This is a long-running test unfortunately.
+		this.timeout( 8000 );
+
+		return runTest( editorCreator );
+	} );
+}
+
+// Runs a single test case. This method will properly setup memory-leak test:
+// - create editor
+// - run garbage collector
+// - record memory allocations
+// - destroy the editor
+// - create & destroy editor multiple times (6) - after each editor creation the test runner will be paused for ~200ms
+function runTest( editorCreator ) {
+	const createEditor = createAndDestroy( editorCreator );
+
+	let memoryAfterFirstStart;
+
+	return Promise.resolve() // Promise.resolve just to align below code.
+	// First editor creation needed to load all editor code,css into the memory (it is reported as used heap memory)
+		.then( createEditor )
+		// Wait for any delayed actions (after editor creation)
+		.then( wait( 200 ) )
+		.then( collectGarbageAndWait )
+		.then( editor => {
+			memoryAfterFirstStart = snapMemInfo();
+
+			return editor;
+		} )
+		.then( destroy )
+		// Run create-wait-destroy multiple times. Multiple runs to grow memory significantly even on smaller leaks.
+		.then( testWaitAndDestroy )
+		.then( testWaitAndDestroy )
+		.then( testWaitAndDestroy )
+		.then( testWaitAndDestroy )
+		.then( testWaitAndDestroy )
+		.then( testWaitAndDestroy )
+		// Finally enforce garbage collection to ensure memory is freed before measuring heap size.
+		.then( collectGarbageAndWait )
+		.then( () => {
+			const memory = snapMemInfo();
+
+			const memoryDifference = memory.usedJSHeapSize - memoryAfterFirstStart.usedJSHeapSize;
+
+			expect( memoryDifference, 'used heap size should not grow above 1 MB' ).to.be.below( MiB );
+		} );
+
+	function testWaitAndDestroy() {
+		return Promise.resolve()
+			.then( createEditor )
+			.then( wait( 200 ) )
+			.then( destroy );
+	}
+}
+
+function createEditorElement() {
+	const editorElement = document.createElement( 'div' );
+	editorElement.id = 'mem-editor';
+
+	editorElement.innerHTML =
+		'<h2>Editor 1</h2>\n' +
+		'<p>This is an editor instance. And there\'s <a href="http://ckeditor.com">some link</a>.</p>';
+
+	document.body.appendChild( editorElement );
+}
+
+function destroyEditorElement() {
+	document.getElementById( 'mem-editor' ).remove();
+}
+
+function createAndDestroy( editorCreator ) {
+	return () => editorCreator();
+}
+
+function destroy( editor ) {
+	return editor.destroy();
+}
+
+function snapMemInfo() {
+	const memeInfo = window.performance.memory;
+
+	return {
+		totalJSHeapSize: memeInfo.totalJSHeapSize,
+		usedJSHeapSize: memeInfo.usedJSHeapSize,
+		jsHeapSizeLimit: memeInfo.jsHeapSizeLimit
+	};
+}
+
+// Will skip test suite if not in compatible browser.
+// Currently on Google Chrome supports this method and must be run with proper flags:
+//
+// 		google-chrome -js-flags="--expose-gc"
+//
+function skipIfNoGarbageCollector() {
+	before( function() {
+		if ( !window.gc ) {
+			this.skip();
+		}
+	} );
+}
+
+function collectGarbageAndWait( pass ) {
+	window.gc();
+
+	return Promise.resolve( pass ).then( wait( 500 ) );
+}
+
+// Simple method that returns a helper method that returns a promise which resolves after given timeout.
+// The returned promise will pass the value from previus call (usually and editor instance).
+function wait( ms ) {
+	return editor => new Promise( resolve => setTimeout( () => resolve( editor ), ms ) );
+}

--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -9,6 +9,22 @@ const TEST_TIMEOUT = 6000;
 const GARBAGE_COLLECTOR_TIMEOUT = 500;
 
 /**
+ * Memory tests suite definition that:
+ * - skips tests when garbage collector is not available.
+ * - creates/destroys editor element (id = 'mem-editor').
+ *
+ * This method should be used with dedicated memory usage test case functions:
+ *
+ *        describe( 'editor', () => {
+ *			// Other tests.
+ *
+ *			describeMemoryUsage( () => {
+ *				testMemoryUsage( 'and editor', () => {
+ *					return ClassicEditor.create( document.querySelector( '#mem-editor' ) );
+ *				} );
+ *			} );
+ *		} );
+ *
  * @param {Function} callback Callback with test suit body
  */
 export function describeMemoryUsage( callback ) {
@@ -24,7 +40,16 @@ export function describeMemoryUsage( callback ) {
 }
 
 /**
- * @param {String} testName
+ * Single test case for memory usage test. This method will handle memory usage test procedure:
+ * - creating editor instance
+ * - recording its memory usage (after garbage collector)
+ * - create and destroy editor 10 times
+ * - record memory usage after final editor destroy (after garbage collector)
+ * - tests if memory grew
+ *
+ * See {@link describeMemoryUsage} function for usage details.
+ *
+ * @param {String} testName Name of a test case.
  * @param {Function} editorCreator Callback which creates editor and returns it's `.create()` promise.
  */
 export function testMemoryUsage( testName, editorCreator ) {
@@ -40,7 +65,7 @@ export function testMemoryUsage( testName, editorCreator ) {
 // - run garbage collector
 // - record memory allocations
 // - destroy the editor
-// - create & destroy editor multiple times (6) - after each editor creation the test runner will be paused for ~200ms
+// - create & destroy editor multiple times (9) - after each editor creation the test runner will be paused for ~200ms
 function runTest( editorCreator ) {
 	const createEditor = createAndDestroy( editorCreator );
 
@@ -58,16 +83,15 @@ function runTest( editorCreator ) {
 		} )
 		.then( destroy )
 		// Run create-wait-destroy multiple times. Multiple runs to grow memory significantly even on smaller leaks.
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
-		.then( testAndDestroy )
+		.then( testAndDestroy ) // #2
+		.then( testAndDestroy ) // #3
+		.then( testAndDestroy ) // #4
+		.then( testAndDestroy ) // #5
+		.then( testAndDestroy ) // #6
+		.then( testAndDestroy ) // #7
+		.then( testAndDestroy ) // #8
+		.then( testAndDestroy ) // #9
+		.then( testAndDestroy ) // #10
 		.then( () => {
 			return new Promise( resolve => {
 				collectMemoryStats().then( memory => {

--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -33,6 +33,10 @@ export function testMemoryUsage( testName, editorCreator ) {
 		// This is a long-running test unfortunately.
 		this.timeout( 8000 );
 
+		// It happens from time to time that Browser will allocate additional resources and the test will fail slightly by ~100-200kB.
+		// In such scenarios another run of test should pass.
+		this.retries( 2 );
+
 		return runTest( editorCreator );
 	} );
 }

--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -5,6 +5,9 @@
 
 /* global window, document, setTimeout */
 
+const TEST_TIMEOUT = 6000;
+const GARBAGE_COLLECTOR_TIMEOUT = 500;
+
 /**
  * @param {Function} callback Callback with test suit body
  */
@@ -26,7 +29,7 @@ export function describeMemoryUsage( callback ) {
  */
 export function testMemoryUsage( testName, editorCreator ) {
 	it( testName, function() {
-		this.timeout( 6000 );
+		this.timeout( TEST_TIMEOUT );
 
 		return runTest( editorCreator );
 	} );
@@ -119,7 +122,7 @@ function collectMemoryStats() {
 				usedJSHeapSize: memeInfo.usedJSHeapSize,
 				jsHeapSizeLimit: memeInfo.jsHeapSizeLimit
 			} );
-		}, 500 );
+		}, GARBAGE_COLLECTOR_TIMEOUT );
 	} );
 }
 

--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -25,7 +25,11 @@ export function describeMemoryUsage( callback ) {
  * @param {Function} editorCreator Callback which creates editor and returns it's `.create()` promise.
  */
 export function testMemoryUsage( testName, editorCreator ) {
-	it( testName, () => runTest( editorCreator ) );
+	it( testName, function() {
+		this.timeout( 6000 );
+
+		return runTest( editorCreator );
+	} );
 }
 
 // Runs a single test case. This method will properly setup memory-leak test:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fix memory leaks. Closes ckeditor/ckeditor5#1341.

---

### Additional information

* This PR introduces a test util for testing memory leaks using mocha and requires changes from ckeditor5-dev repo: https://github.com/ckeditor/ckeditor5-dev/pull/473.
* Alternatively the test can be run on manually spawned Chrome instance and attaching to to a karma runner. To run Google Chrome with required flags execute in command line (other Chrome instances must be closed):
```sh
google-chrome \
    -js-flags="--expose-gc" \
    --enable-precise-memory-info \
    --disable-extensions \
    --disable-plugins  \
    --incognito \
    http://localhost:8125
```
* There's a bunch of repos touched, gathered under [ckeditor5 branch](https://github.com/ckeditor/ckeditor5/commits/t/1341):
    - editor-balloon: [PR](https://github.com/ckeditor/ckeditor5-editor-balloon/pull/25)
    - editor-classic: [PR](https://github.com/ckeditor/ckeditor5-editor-classic/pull/78)
    - editor-decoupled: [PR](https://github.com/ckeditor/ckeditor5-editor-decoupled/pull/24)
    - editor-inline: [PR](https://github.com/ckeditor/ckeditor5-editor-inline/pull/44)
    - engine: [PR](https://github.com/ckeditor/ckeditor5-engine/pull/1635)
    - image: [PR](https://github.com/ckeditor/ckeditor5-image/pull/270)
    - link: [PR](https://github.com/ckeditor/ckeditor5-link/pull/212)
    - ~typing: [PR](https://github.com/ckeditor/ckeditor5-typing/pull/177)~ (redundant)
    - ui: [PR](https://github.com/ckeditor/ckeditor5-ui/pull/459)
    - utils: [PR](https://github.com/ckeditor/ckeditor5-utils/pull/270)
    - widget: [PR](https://github.com/ckeditor/ckeditor5-widget/pull/65)

WIP - test are failing.