### PR TITLE
t/ckeditor5/479: Introduced EditorConfig#placeholder

### DIFF
--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -168,3 +168,31 @@
  *
  * @member {String} module:core/editor/editorconfig~EditorConfig#language
  */
+
+/**
+ * Specifies the text displayed in the editor when there is no content (editor is empty). It is intended to
+ * help users locate the editor in the application (form) and prompt them to input the content. Work similarly
+ * as to the native DOM
+ * [`placeholder` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#The_placeholder_attribute)
+ * used by inputs.
+ *
+ *		const config = {
+ *			placeholder: 'Type some text...'
+ *		};
+ *
+ * The placeholder text is displayed as a pseudo–element of an empty paragraph in the editor content.
+ * The paragraph has the `.ck-placeholder` CSS class and the `data-placeholder` attribute.
+ *
+ *		<p data-placeholder="Type some text..." class="ck-placeholder">
+ *			::before
+ *		</p>
+ *
+ * **Note**: Placeholder text can also be set using the `placeholder` attribute of an element passed to
+ * the `create()` method, for instance to
+ * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
+ *
+ * **Note**: This configuration has precedence over the value of the `placeholder` attribute of a DOM
+ * element passed to the `create()` method.
+ *
+ * @member {String} module:core/editor/editorconfig~EditorConfig#placeholder
+ */

--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -194,5 +194,7 @@
  * **Note**: This configuration has precedence over the value of the `placeholder` attribute of a DOM
  * element passed to the `create()` method.
  *
+ * See the {@glink features/placeholder "Editor placeholder" guide} for more information and live examples.
+ *
  * @member {String} module:core/editor/editorconfig~EditorConfig#placeholder
  */

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -94,6 +94,7 @@ describe( 'ClassicTestEditor', () => {
 					expect( view.isRendered ).to.be.true;
 					expect( view.editableElement.tagName ).to.equal( 'DIV' );
 					expect( view.editableElement ).to.equal( view.editable.element );
+					expect( view.editable.name ).to.equal( 'main' );
 				} );
 		} );
 

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -36,7 +36,7 @@ export default class ClassicTestEditor extends Editor {
 		this.ui = new ClassicTestEditorUI( this, new BoxedEditorUIView( this.locale ) );
 
 		// Expose properties normally exposed by the ClassicEditorUI.
-		this.ui.view.editable = new InlineEditableUIView( this.ui.view.locale );
+		this.ui.view.editable = new InlineEditableUIView( this.ui.view.locale, this.editing.view );
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();
@@ -107,8 +107,14 @@ class ClassicTestEditorUI extends EditorUI {
 
 	init( element ) {
 		const view = this.view;
+		const editable = view.editable;
+		const editingView = this.editor.editing.view;
+		const editingRoot = editingView.document.getRoot();
+
+		editable.name = editingRoot.rootName;
 
 		view.render();
+
 		view.main.add( view.editable );
 		view.editableElement = view.editable.element;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Introduced `EditorConfig#placeholder`. Aligned `ClassicTestEditor` to the latest `InlineEditableUIView` API (see ckeditor/ckeditor5#479).

---

Part of the [constellation](https://github.com/ckeditor/ckeditor5/tree/t/479).