### PR TITLE
Tests: Remove all usages of `view.editableElement`

### DIFF
--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -57,7 +57,7 @@ describe( 'ClassicTestEditor', () => {
 			expect( editor.ui ).to.be.instanceOf( EditorUI );
 			expect( editor.ui.view ).to.be.instanceOf( BoxedEditorUIView );
 			expect( editor.ui.view.isRendered ).to.be.false;
-			expect( editor.ui.view.editableElement ).to.be.undefined;
+			expect( editor.ui.getEditableElement() ).to.be.undefined;
 		} );
 
 		it( 'creates main root element', () => {
@@ -89,11 +89,12 @@ describe( 'ClassicTestEditor', () => {
 		it( 'renders the view including #editable and sets #editableElement', () => {
 			return ClassicTestEditor.create( editorElement, { foo: 1 } )
 				.then( editor => {
-					const view = editor.ui.view;
+					const ui = editor.ui;
+					const view = ui.view;
 
 					expect( view.isRendered ).to.be.true;
-					expect( view.editableElement.tagName ).to.equal( 'DIV' );
-					expect( view.editableElement ).to.equal( view.editable.element );
+					expect( ui.getEditableElement().tagName ).to.equal( 'DIV' );
+					expect( ui.getEditableElement() ).to.equal( view.editable.element );
 				} );
 		} );
 

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -109,7 +109,6 @@ class ClassicTestEditorUI extends EditorUI {
 
 		view.render();
 		view.main.add( view.editable );
-		view.editableElement = view.editable.element;
 
 		this._editableElements.set( 'main', view.editable.element );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Remove all usages of `view.editableElement`.

---

### Additional information

Reporting ticket is https://github.com/ckeditor/ckeditor5/issues/1489.
