### PR TITLE
The `getData()` method now accepts `options` parameter

### DIFF
--- a/src/editor/utils/dataapimixin.js
+++ b/src/editor/utils/dataapimixin.js
@@ -67,14 +67,14 @@ export default DataApiMixin;
  * See the {@glink features/markdown Markdown output} guide for more details.
  *
  * Note: Not only is the format of the data configurable, but the type of the `getData()`'s return value does not
- * have to be a string either. You can e.g. return an object or a DOM `DocumentFragment`  if you consider this
+ * have to be a string either. You can e.g. return an object or a DOM `DocumentFragment` if you consider this
  * the right format for you.
  *
  * @method #getData
  * @param {Object} [options]
  * @param {String} [options.rootName='main'] Root name.
- * @param {String} [options.trim='empty'] Whether returned data should be trimmed. This option is set to `empty` by default,
- * which means whenever editor content is considered empty, the empty string will be returned. To turn off trimming completely
- * use `none`. In such cases exact content will be returned (for example `<p>&nbsp;</p>` for empty editor).
+ * @param {String} [options.trim='empty'] Whether returned data should be trimmed. This option is set to `'empty'` by default,
+ * which means that whenever editor content is considered empty, an empty string is returned. To turn off trimming
+ * use `'none'`. In such cases exact content will be returned (for example `'<p>&nbsp;</p>'` for an empty editor).
  * @returns {String} Output data.
  */

--- a/src/editor/utils/dataapimixin.js
+++ b/src/editor/utils/dataapimixin.js
@@ -24,8 +24,8 @@ const DataApiMixin = {
 	/**
 	 * @inheritDoc
 	 */
-	getData() {
-		return this.data.get();
+	getData( options ) {
+		return this.data.get( options );
 	}
 };
 
@@ -71,5 +71,10 @@ export default DataApiMixin;
  * the right format for you.
  *
  * @method #getData
+ * @param {Object} [options]
+ * @param {String} [options.rootName='main'] Root name.
+ * @param {String} [options.trim='empty'] Whether returned data should be trimmed. This option is set to `empty` by default,
+ * which means whenever editor content is considered empty, the empty string will be returned. To turn off trimming completely
+ * use `none`. In such cases exact content will be returned (for example `<p>&nbsp;</p>` for empty editor).
  * @returns {String} Output data.
  */

--- a/tests/editor/utils/dataapimixin.js
+++ b/tests/editor/utils/dataapimixin.js
@@ -6,9 +6,9 @@
 import DataApiMixin from '../../../src/editor/utils/dataapimixin';
 import Editor from '../../../src/editor/editor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
+import testUtils from '../../../tests/_utils/utils';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'DataApiMixin', () => {
 	let editor;

--- a/tests/editor/utils/dataapimixin.js
+++ b/tests/editor/utils/dataapimixin.js
@@ -41,7 +41,6 @@ describe( 'DataApiMixin', () => {
 	} );
 
 	describe( 'getData()', () => {
-
 		testUtils.createSinonSandbox();
 
 		it( 'should be added to editor interface', () => {

--- a/tests/editor/utils/dataapimixin.js
+++ b/tests/editor/utils/dataapimixin.js
@@ -8,6 +8,7 @@ import Editor from '../../../src/editor/editor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'DataApiMixin', () => {
 	let editor;
@@ -40,6 +41,9 @@ describe( 'DataApiMixin', () => {
 	} );
 
 	describe( 'getData()', () => {
+
+		testUtils.createSinonSandbox();
+
 		it( 'should be added to editor interface', () => {
 			expect( editor ).have.property( 'getData' ).to.be.a( 'function' );
 		} );
@@ -48,6 +52,24 @@ describe( 'DataApiMixin', () => {
 			setData( editor.model, 'foo' );
 
 			expect( editor.getData() ).to.equal( 'foo' );
+		} );
+
+		it( 'should get data of the second root', () => {
+			setData( editor.model, 'bar', { rootName: 'secondRoot' } );
+
+			expect( editor.getData( { rootName: 'secondRoot' } ) ).to.equal( 'bar' );
+		} );
+
+		it( 'should pass options object to data.get() method internally', () => {
+			const spy = testUtils.sinon.spy( editor.data, 'get' );
+			const options = { rootName: 'main', trim: 'none' };
+
+			setData( editor.model, 'foo' );
+
+			expect( editor.getData( options ) ).to.equal( 'foo' );
+
+			testUtils.sinon.assert.calledOnce( spy );
+			testUtils.sinon.assert.calledWith( spy, options );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `getData()` method now accepts `options` parameter.

BREAKING CHANGE: The `getData()` method now returns an empty string by default when editor content is empty.

---

### Additional information

Related to https://github.com/ckeditor/ckeditor5-engine/pull/1656. CI should turn green after merging https://github.com/ckeditor/ckeditor5-engine/pull/1656.
