### PR TITLE
t/1517: Editor placeholder should be created from the "placeholder" attribute only when the source element is `<textarea>`.

### DIFF
--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -187,11 +187,10 @@
  *			::before
  *		</p>
  *
- * **Note**: Placeholder text can also be set using the `data-placeholder` attribute of an element passed to
- * the `create()` method, for instance to
- * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
+ * **Note**: Placeholder text can also be set using the `placeholder` attribute if a `<textarea>` is passed to
+ * the `create()` method, e.g. {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
  *
- * **Note**: This configuration has precedence over the value of the `data-placeholder` attribute of a DOM
+ * **Note**: This configuration has precedence over the value of the `placeholder` attribute of a `<textarea>`
  * element passed to the `create()` method.
  *
  * See the {@glink features/placeholder "Editor placeholder" guide} for more information and live examples.

--- a/src/editor/editorconfig.jsdoc
+++ b/src/editor/editorconfig.jsdoc
@@ -187,11 +187,11 @@
  *			::before
  *		</p>
  *
- * **Note**: Placeholder text can also be set using the `placeholder` attribute of an element passed to
+ * **Note**: Placeholder text can also be set using the `data-placeholder` attribute of an element passed to
  * the `create()` method, for instance to
  * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
  *
- * **Note**: This configuration has precedence over the value of the `placeholder` attribute of a DOM
+ * **Note**: This configuration has precedence over the value of the `data-placeholder` attribute of a DOM
  * element passed to the `create()` method.
  *
  * See the {@glink features/placeholder "Editor placeholder" guide} for more information and live examples.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Editor placeholder should be created from the "placeholder" attribute only when the source element is `<textarea>`. (see ckeditor/ckeditor5#1517).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/compare/t/1517?expand=1.
