### PR TITLE
Disabling memory tests

### DIFF
--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -30,7 +30,8 @@ const GARBAGE_COLLECTOR_TIMEOUT = 500;
  * @param {Function} callback Callback with test suit body
  */
 export function describeMemoryUsage( callback ) {
-	describe( 'memory usage', () => {
+	// Skip all memory tests due to https://github.com/ckeditor/ckeditor5/issues/1731.
+	describe.skip( 'memory usage', () => {
 		skipIfNoGarbageCollector();
 
 		beforeEach( createEditorElement );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Skip all memory tests due to a bug after upgrading to `Chrome 74.*`. See ckeditor/ckeditor5#1731 for more details.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
