### PR TITLE
Re-enable memory tests.

### DIFF
--- a/tests/_utils/memory.js
+++ b/tests/_utils/memory.js
@@ -31,7 +31,7 @@ const GARBAGE_COLLECTOR_TIMEOUT = 500;
  */
 export function describeMemoryUsage( callback ) {
 	// Skip all memory tests due to https://github.com/ckeditor/ckeditor5/issues/1731.
-	describe.skip( 'memory usage', () => {
+	describe( 'memory usage', () => {
 		skipIfNoGarbageCollector();
 
 		beforeEach( createEditorElement );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Re-enable memory tests.

---

### Additional information

* It looks like the newest Chrome 75.x does not longer break our memory tests.
