### PR TITLE
Refactor plugin tests to remove global variables.

### DIFF
--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -6,7 +6,7 @@
 import Plugin from '../src/plugin';
 import Editor from '../src/editor/editor';
 
-describe( 'plugin', () => {
+describe( 'Plugin', () => {
 	let editor;
 
 	beforeEach( () => {

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -6,33 +6,35 @@
 import Plugin from '../src/plugin';
 import Editor from '../src/editor/editor';
 
-let editor;
+describe( 'plugin', () => {
+	let editor;
 
-before( () => {
-	editor = new Editor();
-} );
-
-describe( 'constructor()', () => {
-	it( 'should set the `editor` property', () => {
-		const plugin = new Plugin( editor );
-
-		expect( plugin ).to.have.property( 'editor' ).to.equal( editor );
+	beforeEach( () => {
+		editor = new Editor();
 	} );
 
-	describe( 'destroy()', () => {
-		it( 'should be defined', () => {
+	describe( 'constructor()', () => {
+		it( 'should set the `editor` property', () => {
 			const plugin = new Plugin( editor );
 
-			expect( plugin.destroy ).to.be.a( 'function' );
+			expect( plugin ).to.have.property( 'editor' ).to.equal( editor );
 		} );
 
-		it( 'should stop listening', () => {
-			const plugin = new Plugin( editor );
-			const stopListeningSpy = sinon.spy( plugin, 'stopListening' );
+		describe( 'destroy()', () => {
+			it( 'should be defined', () => {
+				const plugin = new Plugin( editor );
 
-			plugin.destroy();
+				expect( plugin.destroy ).to.be.a( 'function' );
+			} );
 
-			expect( stopListeningSpy.calledOnce ).to.equal( true );
+			it( 'should stop listening', () => {
+				const plugin = new Plugin( editor );
+				const stopListeningSpy = sinon.spy( plugin, 'stopListening' );
+
+				plugin.destroy();
+
+				expect( stopListeningSpy.calledOnce ).to.equal( true );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Remove global hooks from plugin tests.

---

### Additional information

I've just stumbled upon plugin tests and I've caught few issues with them:

1. They lacks global describe for `Plugin`.
2. They attached global (so for all tests run in suite that contains this test) hook - fortunately - `before()` (would be tragic if it was global `beforeEach()`).
3. Global `editor` for all the tests run - probably not an issue here but it might be if one of the test would change `editor` behavior while other would expect not changed behavior.

I've used `beforeEach()` instead of `before()` just to be sure that tests don't interfere.
