### PR TITLE
Add support for the `config.initialData` option in `ClassicTestEditor` and `VirtualTestEditor`.

### DIFF
--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -24,7 +24,7 @@ import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '../../tests/_utils/utils';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
-describe.only( 'ClassicTestEditor', () => {
+describe( 'ClassicTestEditor', () => {
 	let editorElement;
 
 	testUtils.createSinonSandbox();

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -177,7 +177,7 @@ describe( 'ClassicTestEditor', () => {
 				} );
 		} );
 
-		it( 'initializes the data with `config.initialData` if this option is provided', () => {
+		it( 'initializes the data controller with `config.initialData` if this option is provided', () => {
 			return ClassicTestEditor.create( editorElement, { initialData: '<p>foo</p>', plugins: [ Paragraph ] } )
 				.then( editor => {
 					expect( editor.getData() ).to.equal( '<p>foo</p>' );
@@ -186,7 +186,7 @@ describe( 'ClassicTestEditor', () => {
 				} );
 		} );
 
-		it( 'initializes the data with an empty string if the `config.initialData` is not provided', () => {
+		it( 'initializes the data controller with an empty string if the `config.initialData` is not provided', () => {
 			return ClassicTestEditor.create( editorElement )
 				.then( editor => {
 					expect( editor.getData() ).to.equal( '' );

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -10,6 +10,7 @@ import ClassicTestEditor from '../../tests/_utils/classictesteditor';
 
 import Plugin from '../../src/plugin';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 import EditorUI from '../../src/editor/editorui';
 import BoxedEditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/boxed/boxededitoruiview';
@@ -171,6 +172,24 @@ describe( 'ClassicTestEditor', () => {
 			return ClassicTestEditor.create( editorElement )
 				.then( editor => {
 					expect( editor.editing.view.getDomRoot() ).to.equal( editor.ui.view.editable.element );
+
+					return editor.destroy();
+				} );
+		} );
+
+		it( 'initializes the data with `config.initialData` if this option is provided', () => {
+			return ClassicTestEditor.create( editorElement, { initialData: '<p>foo</p>', plugins: [ Paragraph ] } )
+				.then( editor => {
+					expect( editor.getData() ).to.equal( '<p>foo</p>' );
+
+					return editor.destroy();
+				} );
+		} );
+
+		it( 'initializes the data with an empty string if the `config.initialData` is not provided', () => {
+			return ClassicTestEditor.create( editorElement )
+				.then( editor => {
+					expect( editor.getData() ).to.equal( '' );
 
 					return editor.destroy();
 				} );

--- a/tests/_utils-tests/virtualtesteditor.js
+++ b/tests/_utils-tests/virtualtesteditor.js
@@ -34,15 +34,17 @@ describe( 'VirtualTestEditor', () => {
 		it( 'mixes DataApiMixin', () => {
 			expect( testUtils.isMixed( VirtualTestEditor, DataApiMixin ) ).to.true;
 		} );
+	} );
 
-		it( 'supports `config.initialData`', () => {
+	describe( 'static create()', () => {
+		it( 'initializes the data controller with the `config.initialData`', () => {
 			return VirtualTestEditor.create( { initialData: '<p>foo</p>', plugins: [ Paragraph ] } )
 				.then( editor => {
 					expect( editor.getData() ).to.equal( '<p>foo</p>' );
 				} );
 		} );
 
-		it( 'initializes an empty editor if the `config.initialData` is not provided', () => {
+		it( 'initializes the data controller with an empty string if the `config.initialData` is not provided', () => {
 			return VirtualTestEditor.create()
 				.then( editor => {
 					expect( editor.getData() ).to.equal( '' );

--- a/tests/_utils-tests/virtualtesteditor.js
+++ b/tests/_utils-tests/virtualtesteditor.js
@@ -9,6 +9,7 @@ import VirtualTestEditor from '../../tests/_utils/virtualtesteditor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import DataApiMixin from '../../src/editor/utils/dataapimixin';
 import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 import testUtils from '../../tests/_utils/utils';
 
@@ -32,6 +33,20 @@ describe( 'VirtualTestEditor', () => {
 
 		it( 'mixes DataApiMixin', () => {
 			expect( testUtils.isMixed( VirtualTestEditor, DataApiMixin ) ).to.true;
+		} );
+
+		it( 'supports `config.initialData`', () => {
+			return VirtualTestEditor.create( { initialData: '<p>foo</p>', plugins: [ Paragraph ] } )
+				.then( editor => {
+					expect( editor.getData() ).to.equal( '<p>foo</p>' );
+				} );
+		} );
+
+		it( 'initializes an empty editor if the `config.initialData` is not provided', () => {
+			return VirtualTestEditor.create()
+				.then( editor => {
+					expect( editor.getData() ).to.equal( '' );
+				} );
 		} );
 	} );
 } );

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -54,7 +54,7 @@ export default class ClassicTestEditor extends Editor {
 	/**
 	 * @inheritDoc
 	 */
-	static create( element, config ) {
+	static create( element, config = {} ) {
 		return new Promise( resolve => {
 			const editor = new this( element, config );
 
@@ -64,7 +64,7 @@ export default class ClassicTestEditor extends Editor {
 					// should be rendered after plugins are initialized.
 					.then( () => editor.ui.init( element ) )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.getEditableElement() ) )
-					.then( () => editor.data.init( getDataFromElement( element ) ) )
+					.then( () => editor.data.init( config.initialData || getDataFromElement( element ) ) )
 					.then( () => {
 						editor.state = 'ready';
 						editor.fire( 'ready' );

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -13,6 +13,8 @@ import ElementReplacer from '@ckeditor/ckeditor5-utils/src/elementreplacer';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import { isElement } from 'lodash-es';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * A simplified classic editor. Useful for testing features.
@@ -24,51 +26,66 @@ export default class ClassicTestEditor extends Editor {
 	/**
 	 * @inheritDoc
 	 */
-	constructor( element, config ) {
+	constructor( sourceElementOrData, config ) {
 		super( config );
 
-		// The element on which the editor has been initialized.
-		this.element = element;
+		if ( isElement( sourceElementOrData ) ) {
+			this.sourceElement = sourceElementOrData;
+		}
 
 		// Use the HTML data processor in this editor.
 		this.data.processor = new HtmlDataProcessor();
+
+		// Create the ("main") root element of the model tree.
+		this.model.document.createRoot();
 
 		this.ui = new ClassicTestEditorUI( this, new BoxedEditorUIView( this.locale ) );
 
 		// Expose properties normally exposed by the ClassicEditorUI.
 		this.ui.view.editable = new InlineEditableUIView( this.ui.view.locale, this.editing.view );
-
-		// Create the ("main") root element of the model tree.
-		this.model.document.createRoot();
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	destroy() {
+		if ( this.sourceElement ) {
+			this.updateSourceElement();
+		}
+
 		this.ui.destroy();
 
 		return super.destroy();
 	}
 
 	/**
-	 * @inheritDoc
+	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
+	 * or the editor's initial data.
+	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
+	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
-	static create( element, config = {} ) {
+	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			const editor = new this( element, config );
+			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
 					// Simulate EditorUI.init() (e.g. like in ClassicEditorUI). The ui#view
 					// should be rendered after plugins are initialized.
-					.then( () => editor.ui.init( element ) )
+					.then( () => editor.ui.init( isElement( sourceElementOrData ) ? sourceElementOrData : null ) )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.getEditableElement() ) )
-					.then( () => editor.data.init( config.initialData || getDataFromElement( element ) ) )
 					.then( () => {
-						editor.state = 'ready';
-						editor.fire( 'ready' );
+						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+							// Documented in core/editor/editorconfig.jsdoc.
+							throw new CKEditorError(
+								'editor-create-initial-data: ' +
+								'The config.initialData option cannot be used together with initial data passed in Editor.create().'
+							);
+						}
+
+						editor.data.init( config.initialData || getInitialData( sourceElementOrData ) );
 					} )
+					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);
 		} );
@@ -104,7 +121,12 @@ class ClassicTestEditorUI extends EditorUI {
 		return this._view;
 	}
 
-	init( element ) {
+	/**
+	 * Initializes the UI.
+	 *
+	 * @param {HTMLElement|null} replacementElement The DOM element that will be the source for the created editor.
+	 */
+	init( replacementElement ) {
 		const view = this.view;
 		const editable = view.editable;
 		const editingView = this.editor.editing.view;
@@ -118,7 +140,9 @@ class ClassicTestEditorUI extends EditorUI {
 
 		this._editableElements.set( 'main', view.editable.element );
 
-		this._elementReplacer.replace( element, view.element );
+		if ( replacementElement ) {
+			this._elementReplacer.replace( replacementElement, view.element );
+		}
 
 		this.fire( 'ready' );
 	}
@@ -137,3 +161,7 @@ class ClassicTestEditorUI extends EditorUI {
 
 mix( ClassicTestEditor, DataApiMixin );
 mix( ClassicTestEditor, ElementApiMixin );
+
+function getInitialData( sourceElementOrData ) {
+	return isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+}

--- a/tests/_utils/virtualtesteditor.js
+++ b/tests/_utils/virtualtesteditor.js
@@ -27,13 +27,15 @@ export default class VirtualTestEditor extends Editor {
 		this.model.document.createRoot();
 	}
 
-	static create( config ) {
+	static create( config = {} ) {
 		return new Promise( resolve => {
 			const editor = new this( config );
 
 			resolve(
 				editor.initPlugins()
 					.then( () => {
+						editor.data.init( config.initialData || '' );
+
 						// Fire `data#ready` event manually as `data#init()` method is not used.
 						editor.data.fire( 'ready' );
 						editor.fire( 'ready' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added support for the `config.initialData` option in `ClassicTestEditor` and `VirtualTestEditor`. Closes ckeditor/ckeditor5#2904.

---

### Additional information

Required by the https://github.com/ckeditor/ckeditor5-watchdog/pull/2. 
