### PR TITLE
t/ckeditor5/1838: Feature: Added an editor instance reference to the native editable DOM element under the ckeditorInstance property.

### DIFF
--- a/src/editor/editorui.js
+++ b/src/editor/editorui.js
@@ -12,6 +12,7 @@ import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 /**
  * A class providing the minimal interface that is required to successfully bootstrap any editor UI.
@@ -54,10 +55,10 @@ export default class EditorUI {
 		/**
 		 * Stores all editable elements used by the editor instance.
 		 *
-		 * @protected
+		 * @private
 		 * @member {Map.<String,HTMLElement>}
 		 */
-		this._editableElements = new Map();
+		this._editableElementsMap = new Map();
 
 		// Informs UI components that should be refreshed after layout change.
 		this.listenTo( editor.editing.view.document, 'layoutChanged', () => this.update() );
@@ -100,7 +101,29 @@ export default class EditorUI {
 
 		this.focusTracker.destroy();
 
-		this._editableElements = new Map();
+		// Clean–up the references to the CKEditor instance stored in the native editable DOM elements.
+		for ( const domElement of this._editableElementsMap.values() ) {
+			domElement.ckeditorInstance = null;
+		}
+
+		this._editableElementsMap = new Map();
+	}
+
+	/**
+	 * Store the native DOM editable element used by the editor under
+	 * a unique name.
+	 *
+	 * @param {String} rootName The unique name of the editable element.
+	 * @param {HTMLElement} domElement The native DOM editable element.
+	 */
+	setEditableElement( rootName, domElement ) {
+		this._editableElementsMap.set( rootName, domElement );
+
+		// Put a reference to the CKEditor instance in the editable native DOM element.
+		// It helps 3rd–party software (browser extensions, other libraries) access and recognize
+		// CKEditor 5 instances (editing roots) and use their API (there is no global editor
+		// instance registry).
+		domElement.ckeditorInstance = this.editor;
 	}
 
 	/**
@@ -110,7 +133,7 @@ export default class EditorUI {
 	 * @returns {HTMLElement|undefined}
 	 */
 	getEditableElement( rootName = 'main' ) {
-		return this._editableElements.get( rootName );
+		return this._editableElementsMap.get( rootName );
 	}
 
 	/**
@@ -119,7 +142,31 @@ export default class EditorUI {
 	 * @returns {Iterable.<String>}
 	 */
 	getEditableElementsNames() {
-		return this._editableElements.keys();
+		return this._editableElementsMap.keys();
+	}
+
+	/**
+	 * Stores all editable elements used by the editor instance.
+	 *
+	 * @protected
+	 * @deprecated
+	 * @member {Map.<String,HTMLElement>}
+	 */
+	get _editableElements() {
+		/**
+		 * The `EditorUI#_editableElements` property has been deprecated and will be remove in the near future.
+		 * Please use {@link #setEditableElement `setEditableElement()`} and {@link #getEditableElement `getEditableElement()`}
+		 * methods instead.
+		 *
+		 * @warning editor-ui-deprecated-editable-elements
+		 * @param {module:core/editor/editorui~EditorUI} editorUI Editor UI instance the property belongs to.
+		 */
+		log.warn(
+			'editor-ui-deprecated-editable-elements: ' +
+			'The EditorUI#_editableElements property has been deprecated and will be remove in the near future.',
+			{ editorUI: this } );
+
+		return this._editableElementsMap;
 	}
 
 	/**

--- a/src/editor/editorui.js
+++ b/src/editor/editorui.js
@@ -154,7 +154,7 @@ export default class EditorUI {
 	 */
 	get _editableElements() {
 		/**
-		 * The `EditorUI#_editableElements` property has been deprecated and will be remove in the near future.
+		 * The `EditorUI#_editableElements` property has been deprecated and will be removed in the near future.
 		 * Please use {@link #setEditableElement `setEditableElement()`} and {@link #getEditableElement `getEditableElement()`}
 		 * methods instead.
 		 *

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -138,7 +138,7 @@ class ClassicTestEditorUI extends EditorUI {
 
 		view.main.add( view.editable );
 
-		this._editableElements.set( 'main', view.editable.element );
+		this.setEditableElement( 'main', view.editable.element );
 
 		if ( replacementElement ) {
 			this._elementReplacer.replace( replacementElement, view.element );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added an editor instance reference to the native editable DOM element under the `ckeditorInstance` property. Closes ckeditor/ckeditor5#1838. 

Implemented the `EditorUI#setEditableElement()` method. 
Deprecated the `EditorUI#_editableElements` property.

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5/pull/1840.
