### PR TITLE
Added error handling to the `editor.execute()` method

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -19,6 +19,7 @@ import EditingKeystrokeHandler from '../editingkeystrokehandler';
 
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * Class representing a basic, generic editor.
@@ -270,7 +271,11 @@ export default class Editor {
 	 * @param {*} [...commandParams] Command parameters.
 	 */
 	execute( ...args ) {
-		this.commands.execute( ...args );
+		try {
+			this.commands.execute( ...args );
+		} catch ( err ) {
+			CKEditorError.rethrowUnexpectedError( err, this );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added custom error handling to the `editor.execute()` method. Part of ckeditor/ckeditor5#1304.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
