### PR TITLE
Rethrown original error in try-catch blocks when the `debug=true` mode is on.

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -275,6 +275,7 @@ export default class Editor {
 			this.commands.execute( ...args );
 		} catch ( err ) {
 			// @if CK_DEBUG // throw err;
+			/* istanbul ignore next */
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -274,6 +274,7 @@ export default class Editor {
 		try {
 			this.commands.execute( ...args );
 		} catch ( err ) {
+			// @if CK_DEBUG // throw err;
 			CKEditorError.rethrowUnexpectedError( err, this );
 		}
 	}

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -391,10 +391,9 @@ describe( 'Editor', () => {
 			}, /^commandcollection-command-not-found:/, editor );
 		} );
 
-		it( 'should catch native errors and wrap them into the CKEditorError errors', () => {
+		it( 'should rethrow native errors as they are in the debug=true mode', () => {
 			const editor = new TestEditor();
 			const error = new TypeError( 'foo' );
-			error.stack = 'bar';
 
 			class SomeCommand extends Command {
 				constructor( editor ) {
@@ -408,15 +407,9 @@ describe( 'Editor', () => {
 
 			editor.commands.add( 'someCommand', new SomeCommand( editor ) );
 
-			expectToThrowCKEditorError( () => {
+			expect( () => {
 				editor.execute( 'someCommand' );
-			}, /unexpected-error/, editor, {
-				originalError: {
-					message: 'foo',
-					stack: 'bar',
-					name: 'TypeError'
-				}
-			} );
+			} ).to.throw( TypeError, /foo/ );
 		} );
 
 		it( 'should rethrow custom CKEditorError errors', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Rethrown original error in try-catch blocks when the `debug=true` mode is on. Part of ckeditor/ckeditor5#5595.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
