### PR TITLE
Add <div> as a common solution for the editor-wrong-element error.

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -331,6 +331,12 @@ mix( Editor, ObservableMixin );
  * Content of an editor should be nicely present to the user and show him how it's going to looks like. Textarea element
  * doesn't support such behavior.
  *
+ * In most cases a `<div>` element can be used:
+ *
+ *		<div id="editor">
+ *			<p>Initial content.</p>
+ *		</div>
+ *
  * Only {@glink builds/guides/overview#classic-editor Classic Editor} has implemented a special system, which
  * **replace** DOM element and load data from it
  * ({@link module:editor-classic/classiceditor~ClassicEditor.create more information}). All other editors

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -331,7 +331,7 @@ mix( Editor, ObservableMixin );
  * Content of an editor should be nicely present to the user and show him how it's going to looks like. Textarea element
  * doesn't support such behavior.
  *
- * In most cases a `<div>` element can be used:
+ * Typically you can use a `div` for storing editor content instead:
  *
  *		<div id="editor">
  *			<p>Initial content.</p>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Add `<div>` as a common solution for the editor-wrong-element error. See ckeditor/ckeditor5#1806.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5/pull/5865
