### PR TITLE
Fixed tests leaking editor instance / DOM element

### DIFF
--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -23,6 +23,7 @@ import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
 import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '../../tests/_utils/utils';
 import { assertCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import { removeEditorBodyOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup';
 
 describe( 'ClassicTestEditor', () => {
 	let editorElement;
@@ -89,6 +90,8 @@ describe( 'ClassicTestEditor', () => {
 
 					expect( editor.config.get( 'foo' ) ).to.equal( 1 );
 					expect( editor.sourceElement ).to.equal( editorElement );
+
+					return editor.destroy();
 				} );
 		} );
 
@@ -102,6 +105,8 @@ describe( 'ClassicTestEditor', () => {
 					expect( ui.getEditableElement().tagName ).to.equal( 'DIV' );
 					expect( ui.getEditableElement() ).to.equal( view.editable.element );
 					expect( view.editable.name ).to.equal( 'main' );
+
+					return editor.destroy();
 				} );
 		} );
 
@@ -117,6 +122,8 @@ describe( 'ClassicTestEditor', () => {
 			return ClassicTestEditor.create( editorElement, { plugins: [ PluginTextInRoot ] } )
 				.then( editor => {
 					expect( getData( editor.model, { withoutSelection: true } ) ).to.equal( 'foo' );
+
+					return editor.destroy();
 				} );
 		} );
 
@@ -226,6 +233,7 @@ describe( 'ClassicTestEditor', () => {
 					throw new Error( 'It should throw an error' );
 				}, err => {
 					assertCKEditorError( err, /^editor-create-initial-data:/, null );
+					removeEditorBodyOrphans();
 				} );
 		} );
 	} );

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -23,7 +23,7 @@ import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
 import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '../../tests/_utils/utils';
 import { assertCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
-import { removeEditorBodyOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup';
+import { removeEditorBodyOrphans } from '../_utils/cleanup';
 
 describe( 'ClassicTestEditor', () => {
 	let editorElement;

--- a/tests/_utils-tests/cleanup.js
+++ b/tests/_utils-tests/cleanup.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document */
+
+import Locale from '@ckeditor/ckeditor5-utils/src/locale';
+import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
+import { removeEditorBodyOrphans } from '../_utils/cleanup';
+
+describe( 'cleanup util', () => {
+	describe( 'removeEditorBodyOrphans()', () => {
+		const locale = new Locale();
+		const uiViews = [ new EditorUIView( locale ), new EditorUIView( locale ) ];
+
+		for ( const view of uiViews ) {
+			view.render();
+		}
+
+		expect( document.querySelectorAll( '.ck-body' ) ).to.have.length( 2 );
+
+		removeEditorBodyOrphans();
+
+		expect( document.querySelectorAll( '.ck-body' ) ).to.have.length( 0 );
+	} );
+} );

--- a/tests/_utils/cleanup.js
+++ b/tests/_utils/cleanup.js
@@ -17,21 +17,3 @@ export function removeEditorBodyOrphans() {
 		bodyOrphan.remove();
 	}
 }
-
-/**
- * Searches for orphaned editors based on DOM.
- *
- * This is useful if in your tests you have no access to editor, instance because editor
- * creation method doesn't complete in a graceful manner.
- */
-export function destroyEditorOrphans() {
-	const promises = [];
-
-	for ( const editableOrphan of document.querySelectorAll( '.ck-editor__editable' ) ) {
-		if ( editableOrphan.ckeditorInstance ) {
-			promises.push( editableOrphan.ckeditorInstance.destroy() );
-		}
-	}
-
-	return Promise.all( promises );
-}

--- a/tests/_utils/cleanup.js
+++ b/tests/_utils/cleanup.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+/**
+ * Removes all the `.ck-body` elements available in the DOM.
+ *
+ * It is commonly used to cleanup after editors that test editor crashes.
+ *
+ * See https://github.com/ckeditor/ckeditor5/issues/6018 for more details.
+ */
+export function removeEditorBodyOrphans() {
+	for ( const bodyOrphan of document.querySelectorAll( '.ck-body' ) ) {
+		bodyOrphan.remove();
+	}
+}
+
+/**
+ * Searches for orphaned editors based on DOM.
+ *
+ * This is useful if in your tests you have no access to editor, instance because editor
+ * creation method doesn't complete in a graceful manner.
+ */
+export function destroyEditorOrphans() {
+	const promises = [];
+
+	for ( const editableOrphan of document.querySelectorAll( '.ck-editor__editable' ) ) {
+		if ( editableOrphan.ckeditorInstance ) {
+			promises.push( editableOrphan.ckeditorInstance.destroy() );
+		}
+	}
+
+	return Promise.all( promises );
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Fixed tests leaking editor instances / DOM elements. See ckeditor/ckeditor5#6002.

---

### Additional information

This PR also adds a set of test utility cleanup methods to be reused by other tests.

For a complete list of PRs see https://github.com/ckeditor/ckeditor5/issues/6002#issuecomment-567834563.