### PR TITLE
Introduced copying builtin plugins to get rid of shared references between editors [watchdog]

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -229,7 +229,7 @@ export default class Editor {
 	 */
 	initPlugins() {
 		const config = this.config;
-		const plugins = config.get( 'plugins' ) || [];
+		const plugins = config.get( 'plugins' );
 		const removePlugins = config.get( 'removePlugins' ) || [];
 		const extraPlugins = config.get( 'extraPlugins' ) || [];
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -61,6 +61,8 @@ export default class Editor {
 		this._context = config.context || new Context( { language: config.language } );
 		this._context._addEditor( this, !config.context );
 
+		// Clone the plugins to make sure that the plugin array will not be shared
+		// between editors and make the watchdog feature work correctly.
 		const availablePlugins = Array.from( this.constructor.builtinPlugins || [] );
 
 		/**

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -61,7 +61,7 @@ export default class Editor {
 		this._context = config.context || new Context( { language: config.language } );
 		this._context._addEditor( this, !config.context );
 
-		const availablePlugins = this.constructor.builtinPlugins;
+		const availablePlugins = Array.from( this.constructor.builtinPlugins || [] );
 
 		/**
 		 * Stores all configurations specific to this editor instance.

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -265,6 +265,22 @@ describe( 'Editor', () => {
 			expect( editor.config.get( 'plugins' ) ).to.be.empty;
 		} );
 
+		it( 'should copy builtin plugins', async () => {
+			TestEditor.builtinPlugins = [ PluginA ];
+
+			class ContextPlugin {
+				static get isContextPlugin() {
+					return true;
+				}
+			}
+
+			const context = await Context.create( { plugins: [ ContextPlugin ] } );
+			const editor = await TestEditor.create( { context } );
+
+			expect( editor.config.get( 'plugins' ) ).to.deep.equal( [ PluginA ] );
+			expect( editor.config.get( 'plugins' ) ).to.not.equal( TestEditor.builtinPlugins );
+		} );
+
 		it( 'should pass DOM element using reference, not copy', async () => {
 			const element = document.createElement( 'div' );
 			const context = await Context.create( { efoo: element } );

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -262,7 +262,7 @@ describe( 'Editor', () => {
 			const context = await Context.create( { plugins: [ ContextPlugin ] } );
 			const editor = await TestEditor.create( { context } );
 
-			expect( editor.config.get( 'plugins' ) ).to.be.undefined;
+			expect( editor.config.get( 'plugins' ) ).to.be.empty;
 		} );
 
 		it( 'should pass DOM element using reference, not copy', async () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Introduced copying builtin plugins to get rid of shared references between editors [watchdog]. Part of ckeditor/ckeditor5#6219.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
