### PR TITLE
Added tests/_utils to files entry of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "files": [
     "lang",
     "src",
-    "theme"
+    "theme",
+    "tests/_utils"
   ],
   "scripts": {
     "lint": "eslint --quiet '**/*.js'",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The test/\_utils are not exposed to applications depending on this package. Closes ckeditor/ckeditor5#6313.

---

### Additional information

I wasn't able to test it because it needs a real publishing for that, but it seems to be right.